### PR TITLE
Reveal art jam theme when jam starts

### DIFF
--- a/html/art-jams.php
+++ b/html/art-jams.php
@@ -24,9 +24,10 @@ if (!function_exists('aj_parseSchedule')) {
         if (isset($map[$day])) $day = $map[$day];
         return [$day, $hour, $min];
     }
-    function aj_nextOccurrence(DateTimeImmutable $now, string $weekday, int $hour, int $minute, DateTimeZone $tz): DateTimeImmutable {
-        $candidate = (new DateTimeImmutable("this $weekday", $tz))->setTime($hour,$minute,0);
-        if ($candidate < $now) $candidate = (new DateTimeImmutable("next $weekday", $tz))->setTime($hour,$minute,0);
+    function aj_nextOccurrence(DateTimeImmutable $base, string $weekday, int $hour, int $minute, DateTimeZone $tz): DateTimeImmutable {
+        $base = $base->setTimezone($tz);
+        $candidate = $base->modify("this $weekday")->setTime($hour,$minute,0);
+        if ($candidate < $base) $candidate = $base->modify("next $weekday")->setTime($hour,$minute,0);
         return $candidate;
     }
     function aj_weekSeed(DateTimeImmutable $dt): string { return $dt->format('o') . 'W' . $dt->format('W'); }
@@ -394,7 +395,7 @@ $(function() {
   // Use epoch ms from PHP (server is in America/Sao_Paulo)
   const startAt  = <?= $jamStart->getTimestamp()  ?> * 1000;
   const unlockAt = <?= $unlockAt->getTimestamp() ?> * 1000;
-  const endAt    = startAt + 3*hour; // exactly 3 hours after start
+  const endAt    = <?= $jamEnd->getTimestamp()    ?> * 1000; // exactly 3 hours after start
 
 
   let intervalId = null;

--- a/html/art-jams.php
+++ b/html/art-jams.php
@@ -210,8 +210,25 @@ try {
     animation-duration: 1s;
 }
 
+#aj-theme {
+    background-color: #fff3cd;
+    border: 2px dashed #f77f00;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    text-align: center;
+}
+
+#aj-theme.theme-reveal {
+    animation: fadeIn 0.5s ease-in-out;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: scale(0.95); }
+    to { opacity: 1; transform: scale(1); }
+}
+
     </style>
-    <?php 
+    <?php
     
     require("php-components/base-page-components.php");
 
@@ -317,8 +334,10 @@ try {
             <span class="badge text-bg-secondary mb-1">Locked</span>
             <div class="fw-semibold">Subject appears 5 minutes before start.</div>
           <?php else: ?>
-            <div class="fw-semibold"><?= htmlspecialchars($thisSubject ?? '') ?></div>
-            <div class="text-muted small">Constraint: <?= htmlspecialchars($thisConstraint ?? '') ?></div>
+            <div id="aj-theme" class="d-none">
+              <div class="fw-semibold"><?= htmlspecialchars($thisSubject ?? '') ?></div>
+              <div class="text-muted small">Constraint: <?= htmlspecialchars($thisConstraint ?? '') ?></div>
+            </div>
           <?php endif; ?>
         </div>
         <div class="alert alert-info mt-3 mb-0">
@@ -374,7 +393,7 @@ $(function() {
   // Use epoch ms from PHP (server is in America/Sao_Paulo)
   const startAt  = <?= $jamStart->getTimestamp()  ?> * 1000;
   const unlockAt = <?= $unlockAt->getTimestamp() ?> * 1000;
-  const endAt    = <?= $jamEnd->getTimestamp()    ?> * 1000;
+  const endAt    = startAt + 3*hour; // exactly 3 hours after start
 
 
   let intervalId = null;
@@ -418,6 +437,10 @@ $(function() {
     const $title = $('#aj-title');
     if (p === 'in-progress') {
       $title.text('Time Remaining in Jam');
+      const $theme = $('#aj-theme');
+      if ($theme.hasClass('d-none')) {
+        $theme.removeClass('d-none').addClass('theme-reveal');
+      }
     } else if (p === 'ended') {
       $title.text('Jam Ended');
     } else {

--- a/html/art-jams.php
+++ b/html/art-jams.php
@@ -55,8 +55,9 @@ $now = new DateTimeImmutable('now', $tz);
 try {
     [$weekday,$hour,$minute] = aj_parseSchedule($scheduleString);
 
-    // This upcoming jam
-    $jamStart = aj_nextOccurrence($now,$weekday,$hour,$minute,$tz);
+    // This week's jam (or next if the previous one just ended)
+    // Subtract the duration so a jam currently in progress is recognized
+    $jamStart = aj_nextOccurrence($now->sub($jamDuration),$weekday,$hour,$minute,$tz);
     $jamEnd   = $jamStart->add($jamDuration);
     $unlockAt = $jamStart->sub($subjectUnlockLead);
 


### PR DESCRIPTION
## Summary
- Hide weekly art jam theme/constraint until the jam begins
- Reveal theme in progress with a fade-in animation
- Ensure countdown end time is exactly three hours after start

## Testing
- `php -l html/art-jams.php`


------
https://chatgpt.com/codex/tasks/task_b_6896b85cf3a48333960e4d79ba14b335