### PR TITLE
Add pixel editor module and include script in media selector

### DIFF
--- a/html/assets/js/pixel-editor.js
+++ b/html/assets/js/pixel-editor.js
@@ -1,0 +1,265 @@
+(function(global){
+  'use strict';
+
+  // Utility
+  function clamp8(v){ return v<0?0:(v>255?255:v)|0; }
+
+  // Adjustments
+  function applyAdjustments(ctx, w, h, bri, con, sat){
+    const img = ctx.getImageData(0,0,w,h);
+    const d = img.data;
+    const b = bri/100 * 255;
+    const c = (con/100)+1;
+    const intercept = 128*(1-c);
+    const s = sat/100;
+    for(let i=0;i<d.length;i+=4){
+      let r=d[i], g=d[i+1], bl=d[i+2];
+      r = c*r + intercept + b;
+      g = c*g + intercept + b;
+      bl = c*bl + intercept + b;
+      const avg=(r+g+bl)/3;
+      r = avg + (r-avg)*s;
+      g = avg + (g-avg)*s;
+      bl = avg + (bl-avg)*s;
+      d[i]=clamp8(r); d[i+1]=clamp8(g); d[i+2]=clamp8(bl);
+    }
+    ctx.putImageData(img,0,0);
+  }
+
+  function rgbToHsl(r,g,b){
+    r/=255; g/=255; b/=255;
+    const max=Math.max(r,g,b), min=Math.min(r,g,b);
+    let h=0,s=0; const l=(max+min)/2;
+    if(max!==min){
+      const d=max-min;
+      s = l>0.5 ? d/(2-max-min) : d/(max+min);
+      switch(max){
+        case r: h=(g-b)/d+(g<b?6:0); break;
+        case g: h=(b-r)/d+2; break;
+        case b: h=(r-g)/d+4; break;
+      }
+      h*=60;
+    }
+    return {h, s, l};
+  }
+
+  function hslToRgb(h,s,l){
+    const c=(1-Math.abs(2*l-1))*s, hp=h/60, x=c*(1-Math.abs((hp%2)-1));
+    let r1=0,g1=0,b1=0;
+    if(0<=hp&&hp<1){r1=c;g1=x;} else if(1<=hp&&hp<2){r1=x;g1=c;}
+    else if(2<=hp&&hp<3){g1=c;b1=x;} else if(3<=hp&&hp<4){g1=x;b1=c;}
+    else if(4<=hp&&hp<5){r1=x;b1=c;} else if(5<=hp&&hp<6){r1=c;b1=x;}
+    const m=l-c/2;
+    return {r:clamp8((r1+m)*255), g:clamp8((g1+m)*255), b:clamp8((b1+m)*255)};
+  }
+
+  function applyColorTuning(ctx, w, h, gains){
+    const img = ctx.getImageData(0,0,w,h);
+    const d=img.data;
+    const buckets=[{k:'R',h:0},{k:'Y',h:60},{k:'G',h:120},{k:'C',h:180},{k:'B',h:240},{k:'M',h:300}];
+    const nearest = (hh)=>{ let bk='R',bd=1e9; for(const b of buckets){ const diff=Math.min(Math.abs(hh-b.h), 360-Math.abs(hh-b.h)); if(diff<bd){bd=diff; bk=b.k;} } return bk; };
+    for(let i=0;i<d.length;i+=4){
+      const r=d[i], g=d[i+1], bl=d[i+2];
+      const hsl=rgbToHsl(r,g,bl);
+      const band=nearest(hsl.h);
+      const gain=(gains[band]||0)/100;
+      const sat= Math.max(0, Math.min(1, hsl.s*(1+gain)));
+      const rgb = hslToRgb(hsl.h, sat, hsl.l);
+      d[i]=rgb.r; d[i+1]=rgb.g; d[i+2]=rgb.b;
+    }
+    ctx.putImageData(img,0,0);
+  }
+
+  function applyHueRemap(ctx, w, h, mapping, globalStrength){
+    const bandHue=[0,0,60,120,180,240,300];
+    const img = ctx.getImageData(0,0,w,h);
+    const d=img.data;
+    const buckets=[{k:'R',h:0},{k:'Y',h:60},{k:'G',h:120},{k:'C',h:180},{k:'B',h:240},{k:'M',h:300}];
+    const nearest = (hh)=>{ let bk='R',bd=1e9; for(const b of buckets){ const diff=Math.min(Math.abs(hh-b.h), 360-Math.abs(hh-b.h)); if(diff<bd){bd=diff; bk=b.k;} } return bk; };
+    for(let i=0;i<d.length;i+=4){
+      const r=d[i], g=d[i+1], bl=d[i+2];
+      const hsl=rgbToHsl(r,g,bl);
+      const srcBand = nearest(hsl.h);
+      const cfg = mapping[srcBand];
+      if(!cfg) continue;
+      const targetSel = cfg.t;
+      const eff = Math.max(0, Math.min(1, globalStrength * cfg.s));
+      if(targetSel && targetSel>0 && eff>0){
+        const tgtHue = bandHue[targetSel];
+        let dh = ((tgtHue - hsl.h + 540) % 360) - 180;
+        const newH = (hsl.h + dh*eff + 360) % 360;
+        const rgb = hslToRgb(newH, hsl.s, hsl.l);
+        d[i]=rgb.r; d[i+1]=rgb.g; d[i+2]=rgb.b;
+      }
+    }
+    ctx.putImageData(img,0,0);
+  }
+
+  function kmeansRGB(rgba, count, k){
+    const pts=new Array(count);
+    for(let i=0;i<count;i++){ const j=i*4; pts[i]=[rgba[j],rgba[j+1],rgba[j+2]]; }
+    const cents=[]; const rand=m=>Math.floor(Math.random()*m);
+    cents.push(pts[rand(count)]);
+    while(cents.length<k){
+      let farI=0,farV=-1;
+      for(let i=0;i<count;i++){
+        const p=pts[i]; let best=Infinity;
+        for(const c of cents){ const dx=p[0]-c[0],dy=p[1]-c[1],dz=p[2]-c[2]; const d=dx*dx+dy*dy+dz*dz; if(d<best) best=d; }
+        if(best>farV){farV=best; farI=i;}
+      }
+      cents.push(pts[farI]);
+    }
+    const labels=new Uint16Array(count);
+    for(let it=0; it<10; it++){
+      for(let i=0;i<count;i++){
+        const p=pts[i]; let b=0,bd=Infinity;
+        for(let c=0;c<k;c++){
+          const ct=cents[c]; const dx=p[0]-ct[0],dy=p[1]-ct[1],dz=p[2]-ct[2];
+          const d=dx*dx+dy*dy+dz*dz; if(d<bd){bd=d;b=c;}
+        }
+        labels[i]=b;
+      }
+      const sums=new Array(k).fill(0).map(()=>[0,0,0,0]);
+      for(let i=0;i<count;i++){ const s=sums[labels[i]], p=pts[i]; s[0]+=p[0]; s[1]+=p[1]; s[2]+=p[2]; s[3]++; }
+      for(let c=0;c<k;c++){ const s=sums[c]; cents[c]= s[3]>0 ? [(s[0]/s[3])|0,(s[1]/s[3])|0,(s[2]/s[3])|0] : pts[rand(count)]; }
+    }
+    return {palette:cents, labels};
+  }
+
+  function floydSteinbergQuantize(ctx, w, h, levels){
+    const img = ctx.getImageData(0,0,w,h);
+    const d=img.data;
+    const q=v=>Math.round(v*(levels-1)/255)*(255/(levels-1));
+    const at=(x,y)=>(y*w+x)*4;
+    for(let y=0;y<h;y++){
+      for(let x=0;x<w;x++){
+        const i=at(x,y);
+        const oldR=d[i], oldG=d[i+1], oldB=d[i+2];
+        const newR=q(oldR), newG=q(oldG), newB=q(oldB);
+        d[i]=newR; d[i+1]=newG; d[i+2]=newB;
+        const er=oldR-newR, eg=oldG-newG, eb=oldB-newB;
+        distribute(x+1,y,7/16,er,eg,eb);
+        distribute(x-1,y+1,3/16,er,eg,eb);
+        distribute(x,y+1,5/16,er,eg,eb);
+        distribute(x+1,y+1,1/16,er,eg,eb);
+      }
+    }
+    ctx.putImageData(img,0,0);
+
+    function distribute(x,y,c,er,eg,eb){
+      if(x<0||x>=w||y<0||y>=h) return;
+      const j=at(x,y);
+      d[j]+=er*c; d[j+1]+=eg*c; d[j+2]+=eb*c;
+    }
+  }
+
+  function initPixelEditor(container, sourceImage){
+    const pixelWidth = container.querySelector('[data-pixel-width]');
+    const method = container.querySelector('[data-method]');
+    const paletteSize = container.querySelector('[data-palette-size]');
+    const ditherCk = container.querySelector('[data-dither]');
+    const bri = container.querySelector('[data-brightness]');
+    const con = container.querySelector('[data-contrast]');
+    const sat = container.querySelector('[data-saturation]');
+    const canvas = container.querySelector('canvas');
+    const ctx = canvas.getContext('2d');
+
+    let img = sourceImage;
+
+    function render(){
+      if(!img) return;
+      const targetW = Math.max(8, Math.min(1024, Number(pixelWidth?.value)||64));
+      const targetH = Math.round((img.naturalHeight/img.naturalWidth) * targetW);
+
+      const small = document.createElement('canvas');
+      small.width = targetW; small.height = targetH;
+      const sctx = small.getContext('2d', { willReadFrequently:true });
+
+      const m = method?.value || 'neighbor';
+      const k = Math.max(2, Math.min(64, Number(paletteSize?.value)||16));
+
+      if(m==='neighbor'){
+        sctx.imageSmoothingEnabled = false;
+        sctx.drawImage(img,0,0,targetW,targetH);
+      } else {
+        const src = document.createElement('canvas');
+        src.width = img.naturalWidth; src.height = img.naturalHeight;
+        const sfull = src.getContext('2d', { willReadFrequently:true });
+        sfull.drawImage(img,0,0);
+        const data = sfull.getImageData(0,0,src.width,src.height).data;
+        if(m==='average'){
+          const outImg = sctx.createImageData(targetW, targetH);
+          const bw = src.width/targetW, bh = src.height/targetH;
+          for(let py=0; py<targetH; py++){
+            for(let px=0; px<targetW; px++){
+              const x0=Math.floor(px*bw), x1=Math.floor((px+1)*bw);
+              const y0=Math.floor(py*bh), y1=Math.floor((py+1)*bh);
+              let r=0,g=0,b=0,c=0;
+              for(let y=y0;y<y1;y++){
+                let idx=(y*src.width + x0)*4;
+                for(let x=x0;x<x1;x++){ r+=data[idx]; g+=data[idx+1]; b+=data[idx+2]; c++; idx+=4; }
+              }
+              if(c===0) c=1;
+              const i=(py*targetW+px)*4;
+              outImg.data[i]=(r/c)|0;
+              outImg.data[i+1]=(g/c)|0;
+              outImg.data[i+2]=(b/c)|0;
+              outImg.data[i+3]=255;
+            }
+          }
+          sctx.putImageData(outImg,0,0);
+        } else if(m==='palette'){
+          const bw = src.width/targetW, bh = src.height/targetH;
+          const grid = new Uint8ClampedArray(targetW*targetH*4);
+          for(let py=0; py<targetH; py++){
+            for(let px=0; px<targetW; px++){
+              const x0=Math.floor(px*bw), x1=Math.floor((px+1)*bw);
+              const y0=Math.floor(py*bh), y1=Math.floor((py+1)*bh);
+              let r=0,g=0,b=0,c=0;
+              for(let y=y0;y<y1;y++){
+                let idx=(y*src.width + x0)*4;
+                for(let x=x0;x<x1;x++){ r+=data[idx]; g+=data[idx+1]; b+=data[idx+2]; c++; idx+=4; }
+              }
+              const i=(py*targetW+px)*4;
+              if(c===0) c=1;
+              grid[i]=(r/c)|0; grid[i+1]=(g/c)|0; grid[i+2]=(b/c)|0; grid[i+3]=255;
+            }
+          }
+          const {palette, labels} = kmeansRGB(grid, targetW*targetH, k);
+          const outImg = new ImageData(targetW, targetH);
+          for(let i=0;i<labels.length;i++){ const j=i*4, p=palette[labels[i]]; outImg.data[j]=p[0]; outImg.data[j+1]=p[1]; outImg.data[j+2]=p[2]; outImg.data[j+3]=255; }
+          sctx.putImageData(outImg,0,0);
+        }
+      }
+
+      applyAdjustments(sctx, targetW, targetH, Number(bri?.value||0), Number(con?.value||0), Number(sat?.value||100));
+
+      if(ditherCk?.checked){
+        floydSteinbergQuantize(sctx, targetW, targetH, 16);
+      }
+
+      canvas.width = targetW; canvas.height = targetH;
+      ctx.imageSmoothingEnabled = false;
+      ctx.clearRect(0,0,canvas.width,canvas.height);
+      ctx.drawImage(small,0,0);
+    }
+
+    [pixelWidth, method, paletteSize, ditherCk, bri, con, sat].forEach(el=>{
+      if(el) el.addEventListener('input', render);
+    });
+
+    render();
+
+    return { render, setImage: (image)=>{ img=image; render(); } };
+  }
+
+  global.initPixelEditor = initPixelEditor;
+  global.pixelEditorUtils = {
+    applyAdjustments,
+    applyColorTuning,
+    applyHueRemap,
+    kmeansRGB,
+    floydSteinbergQuantize
+  };
+
+})(window);

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -30,6 +30,7 @@
 </div>
 
 
+<script src="/assets/js/pixel-editor.js"></script>
 <script>
 
 let currentSelectMediaPage = 1; // default page


### PR DESCRIPTION
## Summary
- move pixel-art rendering utilities into `/assets/js/pixel-editor.js`
- expose `initPixelEditor(container, sourceImage)` to wire controls to a canvas
- load the pixel editor script whenever `select-media.php` is included

## Testing
- `npm test` (fails: no package.json)
- `composer test` (fails: Command "test" is not defined)


------
https://chatgpt.com/codex/tasks/task_b_689788f3f6b08333b71ce2c73bd08dbb