### PR TITLE
Integrate pixelation step in media upload wizard

### DIFF
--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -39,6 +39,7 @@ const itemsPerSelectMediaPage = 6; // or however many you want
 
 <?php if(Kickback\Services\Session::getCurrentAccount()->canUploadImages()) { ?>
 let cropper;
+let pixelEditor;
 let mediaUploadStep = 1;
 function OpenMediaUploadModal()
 {
@@ -97,6 +98,9 @@ function UpdateMediaUploadModal()
     if (mediaUploadStep == 3)
     {
         CropImageFromEditor();
+        const container = document.getElementById('pixelEditor');
+        const source = document.getElementById('imagePreviewEdited');
+        pixelEditor = initPixelEditor(container, source);
         $("#mediaUploadButtonPrev").html("Back");
         $("#mediaUploadButtonNext").hide();
     }
@@ -132,13 +136,17 @@ function CropImageFromEditor()
 
 function SkipPixelation()
 {
-    MediaUploadNextStep();
+    mediaUploadStep = 4;
+    UpdateMediaUploadModal();
 }
 
 function ApplyPixelation()
 {
-    // Pixelation logic placeholder
-    MediaUploadNextStep();
+    const canvas = document.getElementById('pixelCanvas');
+    let imgElement = document.getElementById('imagePreviewEdited');
+    imgElement.src = canvas.toDataURL();
+    mediaUploadStep = 4;
+    UpdateMediaUploadModal();
 }
 
 function MediaUploadNextStep()


### PR DESCRIPTION
## Summary
- Initialize and use pixel editor in media upload wizard to support four-step flow
- Capture pixelated canvas data on apply and skip pixelation without altering edited image

## Testing
- `php -l html/php-components/select-media.php`
- `./meta/phpstan.sh` *(fails: Could not open input file: ./meta/../html/vendor/composer/phpstan/phpstan/phpstan)*
- `composer install` *(fails: curl error 56 while downloading from api.github.com: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68978aee04e48333b9f50912a0b3ee59