### PR TITLE
Delay pixel editor init until image load

### DIFF
--- a/html/assets/js/pixel-editor.js
+++ b/html/assets/js/pixel-editor.js
@@ -4,6 +4,7 @@
   // Utility
   function clamp8(v){ return v<0?0:(v>255?255:v)|0; }
   function debounced(ms, fn){ let t; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a),ms); }; }
+  function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.now(); const remain=ms-(now-last); if(remain<=0){ last=now; fn(...a); } else { clearTimeout(timer); timer=setTimeout(()=>{ last=Date.now(); fn(...a); }, remain); } }; }
 
   // Adjustments
   function applyAdjustments(ctx, w, h, bri, con, sat){
@@ -198,9 +199,10 @@
     let zoom = 1;
 
     function status(msg){ if(statusEl) statusEl.textContent = msg; }
-    function setZoom(z){ zoom=Math.max(1,Math.floor(z)); if(wrap) wrap.style.transform=`scale(${zoom})`; }
-    function fitToViewport(){ if(!canvas.width||!canvas.height||!viewport) return; const availW=viewport.clientWidth-16; const availH=viewport.clientHeight-16; const fit=Math.max(1,Math.floor(Math.min(availW/canvas.width, availH/canvas.height))); setZoom(fit); }
+    function setZoom(z){ zoom=Math.max(0.1,z); if(wrap) wrap.style.transform=`scale(${zoom})`; }
+    function fitToViewport(){ if(!canvas.width||!canvas.height||!viewport) return; const availW=viewport.clientWidth-16; const availH=viewport.clientHeight-16; const fit=Math.min(availW/canvas.width, availH/canvas.height); setZoom(fit); }
     window.addEventListener('resize', ()=>{ if(autoFitCk?.checked) fitToViewport(); });
+    autoFitCk?.addEventListener('change', ()=>{ if(autoFitCk.checked) fitToViewport(); });
 
     function render(){
       if(!img) return;
@@ -303,7 +305,7 @@
       status('Done.');
     }
 
-    const maybeRender = debounced(120, ()=>{ if(autoRenderCk?.checked) render(); });
+    const maybeRender = throttled(120, ()=>{ if(autoRenderCk?.checked) render(); });
 
     [pixelWidth, method, paletteSize, ditherCk, bri, con, sat, enableTune, tR, tY, tG, tC, tB, tM, enableRemap, remapStrength, mapRStr, mapYStr, mapGStr, mapCStr, mapBStr, mapMStr].forEach(el=>{ if(el) el.addEventListener('input', maybeRender); });
     [mapR,mapY,mapG,mapC,mapB,mapM].forEach(el=>{ if(el) el.addEventListener('change', maybeRender); });

--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -231,37 +231,39 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                     </h2>
                                     <div id="pixelAccordionPixelation" class="accordion-collapse collapse show" aria-labelledby="pixelAccordionPixelationHeading">
                                         <div class="accordion-body">
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Pixel width</label>
-                                                <input type="number" class="form-control" data-pixel-width value="64" min="8" max="1024">
+                                                <input type="number" class="form-control form-control-sm" data-pixel-width value="64" min="8" max="1024">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Method</label>
-                                                <select class="form-select" data-method>
+                                                <select class="form-select form-select-sm" data-method>
                                                     <option value="neighbor">Nearest Neighbor</option>
                                                     <option value="average">Block Average</option>
                                                     <option value="palette">Palette (k-means)</option>
                                                 </select>
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Palette size (for k-means)</label>
-                                                <input type="number" class="form-control" data-palette-size value="16" min="2" max="64">
+                                                <input type="number" class="form-control form-control-sm" data-palette-size value="16" min="2" max="64">
                                             </div>
-                                            <div class="form-check mb-2">
-                                                <input class="form-check-input" type="checkbox" data-dither id="pixelDither">
-                                                <label class="form-check-label" for="pixelDither">Dither (FS)</label>
+                                            <div class="d-flex flex-wrap gap-3 mb-2">
+                                                <div class="form-check">
+                                                    <input class="form-check-input" type="checkbox" data-dither id="pixelDither">
+                                                    <label class="form-check-label" for="pixelDither">Dither (FS)</label>
+                                                </div>
+                                                <div class="form-check">
+                                                    <input class="form-check-input" type="checkbox" data-auto-render id="pixelAutoRender" checked>
+                                                    <label class="form-check-label" for="pixelAutoRender">Auto Render</label>
+                                                </div>
+                                                <div class="form-check">
+                                                    <input class="form-check-input" type="checkbox" data-auto-fit id="pixelAutoFit" checked>
+                                                    <label class="form-check-label" for="pixelAutoFit">Auto Fit</label>
+                                                </div>
                                             </div>
-                                        <div class="form-check mb-2">
-                                                <input class="form-check-input" type="checkbox" data-auto-render id="pixelAutoRender" checked>
-                                                <label class="form-check-label" for="pixelAutoRender">Auto Render</label>
-                                            </div>
-                                            <div class="form-check mb-3">
-                                                <input class="form-check-input" type="checkbox" data-auto-fit id="pixelAutoFit" checked>
-                                                <label class="form-check-label" for="pixelAutoFit">Auto Fit</label>
-                                            </div>
-                                            <div class="mb-3 d-flex gap-2">
-                                                <button type="button" class="btn btn-primary" data-render>Render</button>
-                                                <button type="button" class="btn btn-secondary" data-reset>Reset</button>
+                                            <div class="mb-2 d-flex gap-2">
+                                                <button type="button" class="btn btn-primary btn-sm" data-render>Render</button>
+                                                <button type="button" class="btn btn-secondary btn-sm" data-reset>Reset</button>
                                             </div>
                                         </div>
                                     </div>
@@ -272,15 +274,15 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                     </h2>
                                     <div id="pixelAccordionAdjust" class="accordion-collapse collapse" aria-labelledby="pixelAccordionAdjustHeading">
                                         <div class="accordion-body">
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Brightness</label>
                                                 <input type="range" class="form-range" data-brightness min="-100" max="100" value="0">
                                             </div>
-                                            <div class="mb-3">
+                        <div class="mb-2">
                                                 <label class="form-label">Contrast</label>
                                                 <input type="range" class="form-range" data-contrast min="-100" max="100" value="0">
                                             </div>
-                                        <div class="mb-3">
+                                        <div class="mb-2">
                                                 <label class="form-label">Saturation</label>
                                                 <input type="range" class="form-range" data-saturation min="0" max="200" value="100">
                                             </div>
@@ -297,27 +299,27 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                                 <input class="form-check-input" type="checkbox" data-enable-tune id="pixelEnableTune">
                                                 <label class="form-check-label" for="pixelEnableTune">Enable tuning</label>
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Reds</label>
                                                 <input type="range" class="form-range" data-tune-red min="-100" max="100" value="0">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Yellows</label>
                                                 <input type="range" class="form-range" data-tune-yellow min="-100" max="100" value="0">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Greens</label>
                                                 <input type="range" class="form-range" data-tune-green min="-100" max="100" value="0">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Cyans</label>
                                                 <input type="range" class="form-range" data-tune-cyan min="-100" max="100" value="0">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Blues</label>
                                                 <input type="range" class="form-range" data-tune-blue min="-100" max="100" value="0">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Magentas</label>
                                                 <input type="range" class="form-range" data-tune-magenta min="-100" max="100" value="0">
                                             </div>
@@ -334,38 +336,38 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                                 <input class="form-check-input" type="checkbox" data-enable-remap id="pixelEnableRemap">
                                                 <label class="form-check-label" for="pixelEnableRemap">Enable hue remap</label>
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Global remap strength</label>
                                                 <input type="range" class="form-range" data-remap-strength min="0" max="100" value="100">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Reds →</label>
-                                                <select class="form-select mb-1" data-map-r></select>
+                                                <select class="form-select form-select-sm mb-1" data-map-r></select>
                                                 <input type="range" class="form-range" data-map-r-str min="0" max="100" value="100">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Yellows →</label>
-                                                <select class="form-select mb-1" data-map-y></select>
+                                                <select class="form-select form-select-sm mb-1" data-map-y></select>
                                                 <input type="range" class="form-range" data-map-y-str min="0" max="100" value="100">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Greens →</label>
-                                                <select class="form-select mb-1" data-map-g></select>
+                                                <select class="form-select form-select-sm mb-1" data-map-g></select>
                                                 <input type="range" class="form-range" data-map-g-str min="0" max="100" value="100">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Cyans →</label>
-                                                <select class="form-select mb-1" data-map-c></select>
+                                                <select class="form-select form-select-sm mb-1" data-map-c></select>
                                                 <input type="range" class="form-range" data-map-c-str min="0" max="100" value="100">
                                             </div>
-                                            <div class="mb-3">
+        <div class="mb-2">
                                                 <label class="form-label">Blues →</label>
-                                                <select class="form-select mb-1" data-map-b></select>
+                                                <select class="form-select form-select-sm mb-1" data-map-b></select>
                                                 <input type="range" class="form-range" data-map-b-str min="0" max="100" value="100">
                                             </div>
-                                            <div class="mb-3">
+                                            <div class="mb-2">
                                                 <label class="form-label">Magentas →</label>
-                                                <select class="form-select mb-1" data-map-m></select>
+                                                <select class="form-select form-select-sm mb-1" data-map-m></select>
                                                 <input type="range" class="form-range" data-map-m-str min="0" max="100" value="100">
                                             </div>
                                         </div>

--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -226,10 +226,10 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                         <div class="col-md-4" style="height:400px;">
                             <div class="d-flex h-100">
                                 <div class="nav flex-column nav-pills me-2" id="pixelEditorTabs" role="tablist" aria-orientation="vertical">
-                                    <button class="nav-link active" id="pixelTabPixelation" data-bs-toggle="pill" data-bs-target="#pixelPanePixelation" type="button" role="tab" aria-controls="pixelPanePixelation" aria-selected="true" title="Pixelation"><i class="bi bi-grid-3x3"></i></button>
-                                    <button class="nav-link" id="pixelTabAdjust" data-bs-toggle="pill" data-bs-target="#pixelPaneAdjust" type="button" role="tab" aria-controls="pixelPaneAdjust" aria-selected="false" title="Adjustments"><i class="bi bi-sliders"></i></button>
-                                    <button class="nav-link" id="pixelTabTune" data-bs-toggle="pill" data-bs-target="#pixelPaneTune" type="button" role="tab" aria-controls="pixelPaneTune" aria-selected="false" title="Color Tuning"><i class="bi bi-palette"></i></button>
-                                    <button class="nav-link" id="pixelTabHue" data-bs-toggle="pill" data-bs-target="#pixelPaneHue" type="button" role="tab" aria-controls="pixelPaneHue" aria-selected="false" title="Hue Remap"><i class="bi bi-shuffle"></i></button>
+                                    <button class="nav-link active" id="pixelTabPixelation" data-bs-toggle="pill" data-bs-target="#pixelPanePixelation" type="button" role="tab" aria-controls="pixelPanePixelation" aria-selected="true" title="Pixelation"><i class="fa-solid fa-border-all"></i></button>
+                                    <button class="nav-link" id="pixelTabAdjust" data-bs-toggle="pill" data-bs-target="#pixelPaneAdjust" type="button" role="tab" aria-controls="pixelPaneAdjust" aria-selected="false" title="Adjustments"><i class="fa-solid fa-sliders"></i></button>
+                                    <button class="nav-link" id="pixelTabTune" data-bs-toggle="pill" data-bs-target="#pixelPaneTune" type="button" role="tab" aria-controls="pixelPaneTune" aria-selected="false" title="Color Tuning"><i class="fa-solid fa-palette"></i></button>
+                                    <button class="nav-link" id="pixelTabHue" data-bs-toggle="pill" data-bs-target="#pixelPaneHue" type="button" role="tab" aria-controls="pixelPaneHue" aria-selected="false" title="Hue Remap"><i class="fa-solid fa-shuffle"></i></button>
                                 </div>
                                 <div class="tab-content flex-grow-1 overflow-auto" id="pixelEditorTabContent">
                                     <div class="tab-pane fade show active" id="pixelPanePixelation" role="tabpanel" aria-labelledby="pixelTabPixelation">

--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -223,153 +223,133 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                 <div class="wizard-step" id="mediaUploadStep-3">
                     <h1 class="display-6 mb-3">Step 3 - Pixelize Image</h1>
                     <div id="pixelEditor" class="row mb-3">
-                        <div class="col-md-4" style="max-height:400px; overflow-y:auto;">
-                            <div class="accordion accordion-flush" id="pixelEditorAccordion">
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="pixelAccordionPixelationHeading">
-                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#pixelAccordionPixelation" aria-expanded="true" aria-controls="pixelAccordionPixelation">Pixelation</button>
-                                    </h2>
-                                    <div id="pixelAccordionPixelation" class="accordion-collapse collapse show" aria-labelledby="pixelAccordionPixelationHeading">
-                                        <div class="accordion-body">
-                                            <div class="mb-2">
-                                                <label class="form-label">Pixel width</label>
-                                                <input type="number" class="form-control form-control-sm" data-pixel-width value="64" min="8" max="1024">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Method</label>
-                                                <select class="form-select form-select-sm" data-method>
-                                                    <option value="neighbor">Nearest Neighbor</option>
-                                                    <option value="average">Block Average</option>
-                                                    <option value="palette">Palette (k-means)</option>
-                                                </select>
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Palette size (for k-means)</label>
-                                                <input type="number" class="form-control form-control-sm" data-palette-size value="16" min="2" max="64">
-                                            </div>
-                                            <div class="d-flex flex-wrap gap-3 mb-2">
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" data-dither id="pixelDither">
-                                                    <label class="form-check-label" for="pixelDither">Dither (FS)</label>
-                                                </div>
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" data-auto-render id="pixelAutoRender" checked>
-                                                    <label class="form-check-label" for="pixelAutoRender">Auto Render</label>
-                                                </div>
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" data-auto-fit id="pixelAutoFit" checked>
-                                                    <label class="form-check-label" for="pixelAutoFit">Auto Fit</label>
-                                                </div>
-                                            </div>
-                                            <div class="mb-2 d-flex gap-2">
-                                                <button type="button" class="btn btn-primary btn-sm" data-render>Render</button>
-                                                <button type="button" class="btn btn-secondary btn-sm" data-reset>Reset</button>
-                                            </div>
-                                        </div>
-                                    </div>
+                        <div class="col-md-4" style="height:400px;">
+                            <div class="d-flex h-100">
+                                <div class="nav flex-column nav-pills me-2" id="pixelEditorTabs" role="tablist" aria-orientation="vertical">
+                                    <button class="nav-link active" id="pixelTabPixelation" data-bs-toggle="pill" data-bs-target="#pixelPanePixelation" type="button" role="tab" aria-controls="pixelPanePixelation" aria-selected="true" title="Pixelation"><i class="bi bi-grid-3x3"></i></button>
+                                    <button class="nav-link" id="pixelTabAdjust" data-bs-toggle="pill" data-bs-target="#pixelPaneAdjust" type="button" role="tab" aria-controls="pixelPaneAdjust" aria-selected="false" title="Adjustments"><i class="bi bi-sliders"></i></button>
+                                    <button class="nav-link" id="pixelTabTune" data-bs-toggle="pill" data-bs-target="#pixelPaneTune" type="button" role="tab" aria-controls="pixelPaneTune" aria-selected="false" title="Color Tuning"><i class="bi bi-palette"></i></button>
+                                    <button class="nav-link" id="pixelTabHue" data-bs-toggle="pill" data-bs-target="#pixelPaneHue" type="button" role="tab" aria-controls="pixelPaneHue" aria-selected="false" title="Hue Remap"><i class="bi bi-shuffle"></i></button>
                                 </div>
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="pixelAccordionAdjustHeading">
-                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#pixelAccordionAdjust" aria-expanded="false" aria-controls="pixelAccordionAdjust">Adjustments</button>
-                                    </h2>
-                                    <div id="pixelAccordionAdjust" class="accordion-collapse collapse" aria-labelledby="pixelAccordionAdjustHeading">
-                                        <div class="accordion-body">
-                                            <div class="mb-2">
-                                                <label class="form-label">Brightness</label>
-                                                <input type="range" class="form-range" data-brightness min="-100" max="100" value="0">
-                                            </div>
-                        <div class="mb-2">
-                                                <label class="form-label">Contrast</label>
-                                                <input type="range" class="form-range" data-contrast min="-100" max="100" value="0">
-                                            </div>
+                                <div class="tab-content flex-grow-1 overflow-auto" id="pixelEditorTabContent">
+                                    <div class="tab-pane fade show active" id="pixelPanePixelation" role="tabpanel" aria-labelledby="pixelTabPixelation">
                                         <div class="mb-2">
-                                                <label class="form-label">Saturation</label>
-                                                <input type="range" class="form-range" data-saturation min="0" max="200" value="100">
+                                            <label class="form-label">Pixel width</label>
+                                            <input type="number" class="form-control form-control-sm" data-pixel-width value="64" min="8" max="1024">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Method</label>
+                                            <select class="form-select form-select-sm" data-method>
+                                                <option value="neighbor">Nearest Neighbor</option>
+                                                <option value="average">Block Average</option>
+                                                <option value="palette">Palette (k-means)</option>
+                                            </select>
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Palette size (for k-means)</label>
+                                            <input type="number" class="form-control form-control-sm" data-palette-size value="16" min="2" max="64">
+                                        </div>
+                                        <div class="d-flex flex-wrap gap-3 mb-2">
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="checkbox" data-dither id="pixelDither">
+                                                <label class="form-check-label" for="pixelDither">Dither (FS)</label>
+                                            </div>
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="checkbox" data-auto-render id="pixelAutoRender" checked>
+                                                <label class="form-check-label" for="pixelAutoRender">Auto Render</label>
+                                            </div>
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="checkbox" data-auto-fit id="pixelAutoFit" checked>
+                                                <label class="form-check-label" for="pixelAutoFit">Auto Fit</label>
                                             </div>
                                         </div>
-                                    </div>
-                                </div>
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="pixelAccordionTuneHeading">
-                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#pixelAccordionTune" aria-expanded="false" aria-controls="pixelAccordionTune">Color tuning</button>
-                                    </h2>
-                                    <div id="pixelAccordionTune" class="accordion-collapse collapse" aria-labelledby="pixelAccordionTuneHeading">
-                                        <div class="accordion-body">
-                                            <div class="form-check mb-2">
-                                                <input class="form-check-input" type="checkbox" data-enable-tune id="pixelEnableTune">
-                                                <label class="form-check-label" for="pixelEnableTune">Enable tuning</label>
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Reds</label>
-                                                <input type="range" class="form-range" data-tune-red min="-100" max="100" value="0">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Yellows</label>
-                                                <input type="range" class="form-range" data-tune-yellow min="-100" max="100" value="0">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Greens</label>
-                                                <input type="range" class="form-range" data-tune-green min="-100" max="100" value="0">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Cyans</label>
-                                                <input type="range" class="form-range" data-tune-cyan min="-100" max="100" value="0">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Blues</label>
-                                                <input type="range" class="form-range" data-tune-blue min="-100" max="100" value="0">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Magentas</label>
-                                                <input type="range" class="form-range" data-tune-magenta min="-100" max="100" value="0">
-                                            </div>
+                                        <div class="mb-2 d-flex gap-2">
+                                            <button type="button" class="btn btn-primary btn-sm" data-render>Render</button>
+                                            <button type="button" class="btn btn-secondary btn-sm" data-reset>Reset</button>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="accordion-item">
-                                    <h2 class="accordion-header" id="pixelAccordionHueHeading">
-                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#pixelAccordionHue" aria-expanded="false" aria-controls="pixelAccordionHue">Hue remap</button>
-                                    </h2>
-                                    <div id="pixelAccordionHue" class="accordion-collapse collapse" aria-labelledby="pixelAccordionHueHeading">
-                                        <div class="accordion-body">
-                                            <div class="form-check mb-2">
-                                                <input class="form-check-input" type="checkbox" data-enable-remap id="pixelEnableRemap">
-                                                <label class="form-check-label" for="pixelEnableRemap">Enable hue remap</label>
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Global remap strength</label>
-                                                <input type="range" class="form-range" data-remap-strength min="0" max="100" value="100">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Reds →</label>
-                                                <select class="form-select form-select-sm mb-1" data-map-r></select>
-                                                <input type="range" class="form-range" data-map-r-str min="0" max="100" value="100">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Yellows →</label>
-                                                <select class="form-select form-select-sm mb-1" data-map-y></select>
-                                                <input type="range" class="form-range" data-map-y-str min="0" max="100" value="100">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Greens →</label>
-                                                <select class="form-select form-select-sm mb-1" data-map-g></select>
-                                                <input type="range" class="form-range" data-map-g-str min="0" max="100" value="100">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Cyans →</label>
-                                                <select class="form-select form-select-sm mb-1" data-map-c></select>
-                                                <input type="range" class="form-range" data-map-c-str min="0" max="100" value="100">
-                                            </div>
-        <div class="mb-2">
-                                                <label class="form-label">Blues →</label>
-                                                <select class="form-select form-select-sm mb-1" data-map-b></select>
-                                                <input type="range" class="form-range" data-map-b-str min="0" max="100" value="100">
-                                            </div>
-                                            <div class="mb-2">
-                                                <label class="form-label">Magentas →</label>
-                                                <select class="form-select form-select-sm mb-1" data-map-m></select>
-                                                <input type="range" class="form-range" data-map-m-str min="0" max="100" value="100">
-                                            </div>
+                                    <div class="tab-pane fade" id="pixelPaneAdjust" role="tabpanel" aria-labelledby="pixelTabAdjust">
+                                        <div class="mb-2">
+                                            <label class="form-label">Brightness</label>
+        <input type="range" class="form-range" data-brightness min="-100" max="100" value="0">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Contrast</label>
+                                            <input type="range" class="form-range" data-contrast min="-100" max="100" value="0">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Saturation</label>
+                                            <input type="range" class="form-range" data-saturation min="0" max="200" value="100">
+                                        </div>
+                                    </div>
+                                    <div class="tab-pane fade" id="pixelPaneTune" role="tabpanel" aria-labelledby="pixelTabTune">
+                                        <div class="form-check mb-2">
+                                            <input class="form-check-input" type="checkbox" data-enable-tune id="pixelEnableTune">
+                                            <label class="form-check-label" for="pixelEnableTune">Enable tuning</label>
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Reds</label>
+                                            <input type="range" class="form-range" data-tune-red min="-100" max="100" value="0">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Yellows</label>
+                                            <input type="range" class="form-range" data-tune-yellow min="-100" max="100" value="0">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Greens</label>
+                                            <input type="range" class="form-range" data-tune-green min="-100" max="100" value="0">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Cyans</label>
+                                            <input type="range" class="form-range" data-tune-cyan min="-100" max="100" value="0">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Blues</label>
+                                            <input type="range" class="form-range" data-tune-blue min="-100" max="100" value="0">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Magentas</label>
+                                            <input type="range" class="form-range" data-tune-magenta min="-100" max="100" value="0">
+                                        </div>
+                                    </div>
+                                    <div class="tab-pane fade" id="pixelPaneHue" role="tabpanel" aria-labelledby="pixelTabHue">
+                                        <div class="form-check mb-2">
+                                            <input class="form-check-input" type="checkbox" data-enable-remap id="pixelEnableRemap">
+                                            <label class="form-check-label" for="pixelEnableRemap">Enable hue remap</label>
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Global remap strength</label>
+                                            <input type="range" class="form-range" data-remap-strength min="0" max="100" value="100">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Reds →</label>
+                                            <select class="form-select form-select-sm mb-1" data-map-r></select>
+                                            <input type="range" class="form-range" data-map-r-str min="0" max="100" value="100">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Yellows →</label>
+                                            <select class="form-select form-select-sm mb-1" data-map-y></select>
+                                            <input type="range" class="form-range" data-map-y-str min="0" max="100" value="100">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Greens →</label>
+                                            <select class="form-select form-select-sm mb-1" data-map-g></select>
+                                            <input type="range" class="form-range" data-map-g-str min="0" max="100" value="100">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Cyans →</label>
+                                            <select class="form-select form-select-sm mb-1" data-map-c></select>
+                                            <input type="range" class="form-range" data-map-c-str min="0" max="100" value="100">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Blues →</label>
+                                            <select class="form-select form-select-sm mb-1" data-map-b></select>
+                                            <input type="range" class="form-range" data-map-b-str min="0" max="100" value="100">
+                                        </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Magentas →</label>
+                                            <select class="form-select form-select-sm mb-1" data-map-m></select>
+                                            <input type="range" class="form-range" data-map-m-str min="0" max="100" value="100">
                                         </div>
                                     </div>
                                 </div>

--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -222,10 +222,166 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
 
                 <div class="wizard-step" id="mediaUploadStep-3">
                     <h1 class="display-6 mb-3">Step 3 - Pixelize Image</h1>
-                    <div class="row mb-3">
-                        <div class="col-12 d-flex justify-content-center">
-                            <div id="pixelEditor" class="w-100 d-flex justify-content-center">
-                                <canvas id="pixelCanvas"></canvas>
+                    <div id="pixelEditor" class="row mb-3">
+                        <div class="col-md-4" style="max-height:400px; overflow-y:auto;">
+                            <div class="accordion accordion-flush" id="pixelEditorAccordion">
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="pixelAccordionPixelationHeading">
+                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#pixelAccordionPixelation" aria-expanded="true" aria-controls="pixelAccordionPixelation">Pixelation</button>
+                                    </h2>
+                                    <div id="pixelAccordionPixelation" class="accordion-collapse collapse show" aria-labelledby="pixelAccordionPixelationHeading">
+                                        <div class="accordion-body">
+                                            <div class="mb-3">
+                                                <label class="form-label">Pixel width</label>
+                                                <input type="number" class="form-control" data-pixel-width value="64" min="8" max="1024">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Method</label>
+                                                <select class="form-select" data-method>
+                                                    <option value="neighbor">Nearest Neighbor</option>
+                                                    <option value="average">Block Average</option>
+                                                    <option value="palette">Palette (k-means)</option>
+                                                </select>
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Palette size (for k-means)</label>
+                                                <input type="number" class="form-control" data-palette-size value="16" min="2" max="64">
+                                            </div>
+                                            <div class="form-check mb-2">
+                                                <input class="form-check-input" type="checkbox" data-dither id="pixelDither">
+                                                <label class="form-check-label" for="pixelDither">Dither (FS)</label>
+                                            </div>
+                                        <div class="form-check mb-2">
+                                                <input class="form-check-input" type="checkbox" data-auto-render id="pixelAutoRender" checked>
+                                                <label class="form-check-label" for="pixelAutoRender">Auto Render</label>
+                                            </div>
+                                            <div class="form-check mb-3">
+                                                <input class="form-check-input" type="checkbox" data-auto-fit id="pixelAutoFit" checked>
+                                                <label class="form-check-label" for="pixelAutoFit">Auto Fit</label>
+                                            </div>
+                                            <div class="mb-3 d-flex gap-2">
+                                                <button type="button" class="btn btn-primary" data-render>Render</button>
+                                                <button type="button" class="btn btn-secondary" data-reset>Reset</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="pixelAccordionAdjustHeading">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#pixelAccordionAdjust" aria-expanded="false" aria-controls="pixelAccordionAdjust">Adjustments</button>
+                                    </h2>
+                                    <div id="pixelAccordionAdjust" class="accordion-collapse collapse" aria-labelledby="pixelAccordionAdjustHeading">
+                                        <div class="accordion-body">
+                                            <div class="mb-3">
+                                                <label class="form-label">Brightness</label>
+                                                <input type="range" class="form-range" data-brightness min="-100" max="100" value="0">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Contrast</label>
+                                                <input type="range" class="form-range" data-contrast min="-100" max="100" value="0">
+                                            </div>
+                                        <div class="mb-3">
+                                                <label class="form-label">Saturation</label>
+                                                <input type="range" class="form-range" data-saturation min="0" max="200" value="100">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="pixelAccordionTuneHeading">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#pixelAccordionTune" aria-expanded="false" aria-controls="pixelAccordionTune">Color tuning</button>
+                                    </h2>
+                                    <div id="pixelAccordionTune" class="accordion-collapse collapse" aria-labelledby="pixelAccordionTuneHeading">
+                                        <div class="accordion-body">
+                                            <div class="form-check mb-2">
+                                                <input class="form-check-input" type="checkbox" data-enable-tune id="pixelEnableTune">
+                                                <label class="form-check-label" for="pixelEnableTune">Enable tuning</label>
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Reds</label>
+                                                <input type="range" class="form-range" data-tune-red min="-100" max="100" value="0">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Yellows</label>
+                                                <input type="range" class="form-range" data-tune-yellow min="-100" max="100" value="0">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Greens</label>
+                                                <input type="range" class="form-range" data-tune-green min="-100" max="100" value="0">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Cyans</label>
+                                                <input type="range" class="form-range" data-tune-cyan min="-100" max="100" value="0">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Blues</label>
+                                                <input type="range" class="form-range" data-tune-blue min="-100" max="100" value="0">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Magentas</label>
+                                                <input type="range" class="form-range" data-tune-magenta min="-100" max="100" value="0">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="pixelAccordionHueHeading">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#pixelAccordionHue" aria-expanded="false" aria-controls="pixelAccordionHue">Hue remap</button>
+                                    </h2>
+                                    <div id="pixelAccordionHue" class="accordion-collapse collapse" aria-labelledby="pixelAccordionHueHeading">
+                                        <div class="accordion-body">
+                                            <div class="form-check mb-2">
+                                                <input class="form-check-input" type="checkbox" data-enable-remap id="pixelEnableRemap">
+                                                <label class="form-check-label" for="pixelEnableRemap">Enable hue remap</label>
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Global remap strength</label>
+                                                <input type="range" class="form-range" data-remap-strength min="0" max="100" value="100">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Reds →</label>
+                                                <select class="form-select mb-1" data-map-r></select>
+                                                <input type="range" class="form-range" data-map-r-str min="0" max="100" value="100">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Yellows →</label>
+                                                <select class="form-select mb-1" data-map-y></select>
+                                                <input type="range" class="form-range" data-map-y-str min="0" max="100" value="100">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Greens →</label>
+                                                <select class="form-select mb-1" data-map-g></select>
+                                                <input type="range" class="form-range" data-map-g-str min="0" max="100" value="100">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Cyans →</label>
+                                                <select class="form-select mb-1" data-map-c></select>
+                                                <input type="range" class="form-range" data-map-c-str min="0" max="100" value="100">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Blues →</label>
+                                                <select class="form-select mb-1" data-map-b></select>
+                                                <input type="range" class="form-range" data-map-b-str min="0" max="100" value="100">
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Magentas →</label>
+                                                <select class="form-select mb-1" data-map-m></select>
+                                                <input type="range" class="form-range" data-map-m-str min="0" max="100" value="100">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-8">
+                            <div class="mb-2 d-flex justify-content-between">
+                                <span class="text-muted">Pixelated size: <span data-pix-meta>—</span></span>
+                                <span class="text-muted" data-status></span>
+                            </div>
+                            <div data-viewport style="position:relative; overflow:auto; width:100%; height:400px; border:1px solid #dee2e6; border-radius:0.25rem;">
+                                <div data-wrap style="position:relative; width:max-content; height:max-content; transform-origin:top left;">
+                                    <canvas id="pixelCanvas" style="image-rendering:pixelated;"></canvas>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -98,9 +98,26 @@ function UpdateMediaUploadModal()
     if (mediaUploadStep == 3)
     {
         CropImageFromEditor();
-        const container = document.getElementById('pixelEditor');
+        let container = document.getElementById('pixelEditor');
         const source = document.getElementById('imagePreviewEdited');
-        pixelEditor = initPixelEditor(container, source);
+
+        if (pixelEditor) {
+            const newContainer = container.cloneNode(true);
+            container.parentNode.replaceChild(newContainer, container);
+            container = newContainer;
+            pixelEditor = null;
+        }
+
+        const initializeEditor = () => {
+            pixelEditor = initPixelEditor(container, source);
+        };
+
+        if (source.complete) {
+            initializeEditor();
+        } else {
+            source.addEventListener('load', initializeEditor, { once: true });
+        }
+
         $("#mediaUploadButtonPrev").html("Back");
         $("#mediaUploadButtonNext").hide();
     }
@@ -142,6 +159,9 @@ function SkipPixelation()
 
 function ApplyPixelation()
 {
+    if (pixelEditor) {
+        pixelEditor.render();
+    }
     const canvas = document.getElementById('pixelCanvas');
     let imgElement = document.getElementById('imagePreviewEdited');
     imgElement.src = canvas.toDataURL();


### PR DESCRIPTION
## Summary
- Embed full pixel editor controls—auto render/fit, adjustments, color tuning, and hue remap—in upload wizard
- Expand pixel-editor.js to handle all options and reset behavior
- Ensure the editor renders before applying pixelation and wait for the edited image to load before init
- Group pixel editor controls into collapsible accordion panels for a compact UI

## Testing
- `php -l html/php-components/base-page-components.php`
- `php -l html/php-components/select-media.php`


------
https://chatgpt.com/codex/tasks/task_b_68978f62a7408333b557f82d95ff7164