### PR TITLE
Persist pixel editor settings

### DIFF
--- a/html/assets/js/pixel-editor.js
+++ b/html/assets/js/pixel-editor.js
@@ -216,22 +216,6 @@
     }
     if(enableRemap && opts.enableRemap !== undefined) enableRemap.checked = opts.enableRemap;
     if(remapStrength && opts.remapStrength !== undefined) remapStrength.value = opts.remapStrength;
-    if(opts.map){
-      if(mapR) mapR.value = opts.map.R;
-      if(mapY) mapY.value = opts.map.Y;
-      if(mapG) mapG.value = opts.map.G;
-      if(mapC) mapC.value = opts.map.C;
-      if(mapB) mapB.value = opts.map.B;
-      if(mapM) mapM.value = opts.map.M;
-    }
-    if(opts.mapStr){
-      if(mapRStr) mapRStr.value = opts.mapStr.R;
-      if(mapYStr) mapYStr.value = opts.mapStr.Y;
-      if(mapGStr) mapGStr.value = opts.mapStr.G;
-      if(mapCStr) mapCStr.value = opts.mapStr.C;
-      if(mapBStr) mapBStr.value = opts.mapStr.B;
-      if(mapMStr) mapMStr.value = opts.mapStr.M;
-    }
 
     let img = sourceImage;
     let zoom = 1;
@@ -418,6 +402,23 @@
     const remapBands=['— keep —','Red','Yellow','Green','Cyan','Blue','Magenta'];
     function buildOptions(sel){ sel.innerHTML=''; remapBands.forEach((name,i)=>{ const opt=document.createElement('option'); opt.textContent=name; opt.value=String(i); sel.appendChild(opt); }); sel.value='0'; }
     [mapR,mapY,mapG,mapC,mapB,mapM].forEach(sel=>{ if(sel) buildOptions(sel); });
+
+    if(opts.map){
+      if(mapR) mapR.value = opts.map.R;
+      if(mapY) mapY.value = opts.map.Y;
+      if(mapG) mapG.value = opts.map.G;
+      if(mapC) mapC.value = opts.map.C;
+      if(mapB) mapB.value = opts.map.B;
+      if(mapM) mapM.value = opts.map.M;
+    }
+    if(opts.mapStr){
+      if(mapRStr) mapRStr.value = opts.mapStr.R;
+      if(mapYStr) mapYStr.value = opts.mapStr.Y;
+      if(mapGStr) mapGStr.value = opts.mapStr.G;
+      if(mapCStr) mapCStr.value = opts.mapStr.C;
+      if(mapBStr) mapBStr.value = opts.mapStr.B;
+      if(mapMStr) mapMStr.value = opts.mapStr.M;
+    }
 
     collectSettings();
     render();

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -36,6 +36,9 @@
 let currentSelectMediaPage = 1; // default page
 const itemsPerSelectMediaPage = 6; // or however many you want
 
+var pixelEditorSettings = null;
+var lastPixelEditorSrc = '';
+
 
 <?php if(Kickback\Services\Session::getCurrentAccount()->canUploadImages()) { ?>
 let cropper;
@@ -101,6 +104,28 @@ function UpdateMediaUploadModal()
         let container = document.getElementById('pixelEditor');
         const source = document.getElementById('imagePreviewEdited');
 
+        const currentSrc = source.src;
+        if (currentSrc !== lastPixelEditorSrc || !pixelEditorSettings) {
+            pixelEditorSettings = {
+                pixelWidth: 64,
+                method: 'neighbor',
+                paletteSize: 16,
+                dither: false,
+                autoRender: true,
+                autoFit: true,
+                brightness: 0,
+                contrast: 0,
+                saturation: 100,
+                enableTune: false,
+                tune: {R:0, Y:0, G:0, C:0, B:0, M:0},
+                enableRemap: false,
+                remapStrength: 100,
+                map: {R:'0', Y:'0', G:'0', C:'0', B:'0', M:'0'},
+                mapStr: {R:100, Y:100, G:100, C:100, B:100, M:100}
+            };
+        }
+        lastPixelEditorSrc = currentSrc;
+
         if (pixelEditor) {
             const newContainer = container.cloneNode(true);
             container.parentNode.replaceChild(newContainer, container);
@@ -109,7 +134,7 @@ function UpdateMediaUploadModal()
         }
 
         const initializeEditor = () => {
-            pixelEditor = initPixelEditor(container, source);
+            pixelEditor = initPixelEditor(container, source, pixelEditorSettings);
         };
 
         if (source.complete) {
@@ -233,6 +258,8 @@ function OnPhotoUsageChanged(input)
 
 function OnUploadFileChanged(input)
 {
+    pixelEditorSettings = null;
+    lastPixelEditorSrc = '';
     const file = input.files[0];
     
     if (file) {
@@ -405,6 +432,8 @@ function SelectMedia(Id, path) {
 function AcceptSelectedMedia()
 {
     console.log(currentSelectedMediaId);
+    pixelEditorSettings = null;
+    lastPixelEditorSrc = '';
 
     $("#selectMediaModal").modal("hide");
     $("#"+selectMediaModalCallerId).modal("show");

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -100,12 +100,13 @@ function UpdateMediaUploadModal()
 
     if (mediaUploadStep == 3)
     {
-        CropImageFromEditor();
         let container = document.getElementById('pixelEditor');
         const source = document.getElementById('imagePreviewEdited');
+        let currentSrc = source.src;
 
-        const currentSrc = source.src;
         if (currentSrc !== lastPixelEditorSrc || !pixelEditorSettings) {
+            CropImageFromEditor();
+            currentSrc = source.src;
             pixelEditorSettings = {
                 pixelWidth: 64,
                 method: 'neighbor',

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -190,6 +190,7 @@ function ApplyPixelation()
     const canvas = document.getElementById('pixelCanvas');
     let imgElement = document.getElementById('imagePreviewEdited');
     imgElement.src = canvas.toDataURL();
+    lastPixelEditorSrc = imgElement.src;
     mediaUploadStep = 4;
     UpdateMediaUploadModal();
 }

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -38,6 +38,8 @@ const itemsPerSelectMediaPage = 6; // or however many you want
 
 var pixelEditorSettings = null;
 var lastPixelEditorSrc = '';
+var croppedImageData = '';
+var pixelatedImageData = '';
 
 
 <?php if(Kickback\Services\Session::getCurrentAccount()->canUploadImages()) { ?>
@@ -102,10 +104,14 @@ function UpdateMediaUploadModal()
     {
         let container = document.getElementById('pixelEditor');
         const source = document.getElementById('imagePreviewEdited');
+        if (croppedImageData) {
+            source.src = croppedImageData;
+        }
         let currentSrc = source.src;
 
-        if (currentSrc !== lastPixelEditorSrc || !pixelEditorSettings) {
+        if (!croppedImageData || currentSrc !== lastPixelEditorSrc || !pixelEditorSettings) {
             CropImageFromEditor();
+            source.src = croppedImageData;
             currentSrc = source.src;
             pixelEditorSettings = {
                 pixelWidth: 64,
@@ -150,6 +156,12 @@ function UpdateMediaUploadModal()
 
     if (mediaUploadStep == 4)
     {
+        let preview = document.getElementById('imagePreviewEdited');
+        if (pixelatedImageData) {
+            preview.src = pixelatedImageData;
+        } else if (croppedImageData) {
+            preview.src = croppedImageData;
+        }
         $("#mediaUploadButtonPrev").html("Back");
         $("#mediaUploadButtonNext").html("Upload");
     }
@@ -174,11 +186,13 @@ function CropImageFromEditor()
 
     // Set the data URL as the source of the image element
     imgElement.src = dataURL;
-
+    croppedImageData = dataURL;
+    pixelatedImageData = '';
 }
 
 function SkipPixelation()
 {
+    pixelatedImageData = croppedImageData;
     mediaUploadStep = 4;
     UpdateMediaUploadModal();
 }
@@ -190,8 +204,8 @@ function ApplyPixelation()
     }
     const canvas = document.getElementById('pixelCanvas');
     let imgElement = document.getElementById('imagePreviewEdited');
-    imgElement.src = canvas.toDataURL();
-    lastPixelEditorSrc = imgElement.src;
+    pixelatedImageData = canvas.toDataURL();
+    imgElement.src = pixelatedImageData;
     mediaUploadStep = 4;
     UpdateMediaUploadModal();
 }
@@ -262,6 +276,8 @@ function OnUploadFileChanged(input)
 {
     pixelEditorSettings = null;
     lastPixelEditorSrc = '';
+    croppedImageData = '';
+    pixelatedImageData = '';
     const file = input.files[0];
     
     if (file) {
@@ -436,6 +452,8 @@ function AcceptSelectedMedia()
     console.log(currentSelectedMediaId);
     pixelEditorSettings = null;
     lastPixelEditorSrc = '';
+    croppedImageData = '';
+    pixelatedImageData = '';
 
     $("#selectMediaModal").modal("hide");
     $("#"+selectMediaModalCallerId).modal("show");


### PR DESCRIPTION
## Summary
- Preserve pixel editor settings between wizard revisits by storing values in a global object and restoring them when the same image is edited again.
- Update pixel-editor initialization to read and write settings, with change listeners keeping the global state in sync.
- Reset stored settings whenever a new image is loaded so fresh edits start from defaults.

## Testing
- `php -l html/php-components/select-media.php`
- `node --check html/assets/js/pixel-editor.js && echo "syntax ok"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6897ca23eb548333992627184e98418a