### PR TITLE
feat: add pixel editor cleanup

### DIFF
--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -136,6 +136,8 @@ function UpdateMediaUploadModal()
         lastPixelEditorSrc = currentSrc;
 
         if (pixelEditor) {
+            // Clean up listeners from previous editor instance
+            pixelEditor.destroy();
             const newContainer = container.cloneNode(true);
             container.parentNode.replaceChild(newContainer, container);
             container = newContainer;
@@ -173,6 +175,11 @@ function ResetMediaUploadWizardStep2()
 {
     if (cropper) {
         cropper.destroy();
+    }
+    if (pixelEditor) {
+        // Ensure any event listeners from the editor are removed
+        pixelEditor.destroy();
+        pixelEditor = null;
     }
 
     $("#mediaUploadUsageSelect").val("-1");


### PR DESCRIPTION
## Summary
- track all event listeners in `initPixelEditor`
- expose and document `destroy()` to remove listeners
- call `pixelEditor.destroy()` when recreating or resetting the editor

## Testing
- `node --check html/assets/js/pixel-editor.js`
- `php -l html/php-components/select-media.php`


------
https://chatgpt.com/codex/tasks/task_b_6899396c5a7c833393b8aa8909b53a3a