### PR TITLE
refactor: convert pixel editor to module

### DIFF
--- a/html/assets/js/pixel-editor.js
+++ b/html/assets/js/pixel-editor.js
@@ -1,10 +1,9 @@
-(function(global){
-  'use strict';
+'use strict';
 
-  // Utility
-  function clamp8(v){ return v<0?0:(v>255?255:v)|0; }
-  function debounced(ms, fn){ let t; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a),ms); }; }
-  function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.now(); const remain=ms-(now-last); if(remain<=0){ last=now; fn(...a); } else { clearTimeout(timer); timer=setTimeout(()=>{ last=Date.now(); fn(...a); }, remain); } }; }
+// Utility
+function clamp8(v){ return v<0?0:(v>255?255:v)|0; }
+function debounced(ms, fn){ let t; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a),ms); }; }
+function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.now(); const remain=ms-(now-last); if(remain<=0){ last=now; fn(...a); } else { clearTimeout(timer); timer=setTimeout(()=>{ last=Date.now(); fn(...a); }, remain); } }; }
 
   // Adjustments
   function applyAdjustments(ctx, w, h, bri, con, sat){
@@ -177,7 +176,7 @@
    * called when the editor is no longer needed so that all event
    * listeners are removed and memory can be reclaimed.
    */
-  function initPixelEditor(container, sourceImage, settings){
+  export function initPixelEditor(container, sourceImage, settings){
     const pixelWidth = container.querySelector('[data-pixel-width]');
     const method = container.querySelector('[data-method]');
     const paletteSize = container.querySelector('[data-palette-size]');
@@ -249,8 +248,9 @@
     const src   = useOffscreen ? new OffscreenCanvas(0,0) : document.createElement('canvas');
     const worker = opts.worker;
 
-    function collectSettings(){
-      global.pixelEditorSettings = {
+  let currentSettings = {};
+  function collectSettings(){
+      currentSettings = {
         pixelWidth: Number(pixelWidth?.value||64),
         method: method?.value||'neighbor',
         paletteSize: Number(paletteSize?.value||16),
@@ -478,17 +478,17 @@
     return {
       render,
       setImage: (image)=>{ img=image; collectSettings(); render(); },
-      destroy
+      destroy,
+      getSettings: () => { collectSettings(); return currentSettings; }
     };
   }
 
-  global.initPixelEditor = initPixelEditor;
-  global.pixelEditorUtils = {
-    applyAdjustments,
-    applyColorTuning,
-    applyHueRemap,
-    kmeansRGB,
-    floydSteinbergQuantize
-  };
+export { applyAdjustments, applyColorTuning, applyHueRemap, kmeansRGB, floydSteinbergQuantize };
+export const pixelEditorUtils = {
+  applyAdjustments,
+  applyColorTuning,
+  applyHueRemap,
+  kmeansRGB,
+  floydSteinbergQuantize
+};
 
-})(window);

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -30,8 +30,8 @@
 </div>
 
 
-<script src="/assets/js/pixel-editor.js"></script>
-<script>
+<script type="module">
+import { initPixelEditor } from '/assets/js/pixel-editor.js';
 
 let currentSelectMediaPage = 1; // default page
 const itemsPerSelectMediaPage = 6; // or however many you want
@@ -136,7 +136,8 @@ function UpdateMediaUploadModal()
         lastPixelEditorSrc = currentSrc;
 
         if (pixelEditor) {
-            // Clean up listeners from previous editor instance
+            // Preserve current settings and clean up listeners from previous editor instance
+            pixelEditorSettings = pixelEditor.getSettings();
             pixelEditor.destroy();
             const newContainer = container.cloneNode(true);
             container.parentNode.replaceChild(newContainer, container);
@@ -178,6 +179,7 @@ function ResetMediaUploadWizardStep2()
     }
     if (pixelEditor) {
         // Ensure any event listeners from the editor are removed
+        pixelEditorSettings = pixelEditor.getSettings();
         pixelEditor.destroy();
         pixelEditor = null;
     }
@@ -520,5 +522,32 @@ function onPaginationClickSelectMedia(pageNumber) {
     currentSelectMediaPage = pageNumber; // make sure to define this variable globally or pass it around as needed
     SearchForMedia();
 }
+
+// Expose functions for inline event handlers
+window.OpenMediaUploadModal = OpenMediaUploadModal;
+window.CloseMediaUploadModal = CloseMediaUploadModal;
+window.UpdateMediaUploadModal = UpdateMediaUploadModal;
+window.ResetMediaUploadWizardStep2 = ResetMediaUploadWizardStep2;
+window.CropImageFromEditor = CropImageFromEditor;
+window.SkipPixelation = SkipPixelation;
+window.ApplyPixelation = ApplyPixelation;
+window.MediaUploadNextStep = MediaUploadNextStep;
+window.MediaUploadPrevStep = MediaUploadPrevStep;
+window.GetAspectRatio = GetAspectRatio;
+window.InitCropper = InitCropper;
+window.OnPhotoUsageChanged = OnPhotoUsageChanged;
+window.OnUploadFileChanged = OnUploadFileChanged;
+window.UploadImageData = UploadImageData;
+window.ReopenSelectMediaModal = ReopenSelectMediaModal;
+window.OpenSelectMediaModal = OpenSelectMediaModal;
+window.OnSelectMediaChangeSearchParams = OnSelectMediaChangeSearchParams;
+window.SearchForMedia = SearchForMedia;
+window.LoadSearchMediaResults = LoadSearchMediaResults;
+window.ClearSearchMediaResults = ClearSearchMediaResults;
+window.SelectMedia = SelectMedia;
+window.AcceptSelectedMedia = AcceptSelectedMedia;
+window.AddSearchMediaResult = AddSearchMediaResult;
+window.generatePaginationSelectMedia = generatePaginationSelectMedia;
+window.onPaginationClickSelectMedia = onPaginationClickSelectMedia;
 
 </script>


### PR DESCRIPTION
## Summary
- refactor pixel-editor.js into an ES module exporting `initPixelEditor` and utility helpers
- expose editor settings via `getSettings` instead of `window.pixelEditorSettings`
- adjust media selector to import the module and persist settings between instances

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68993f8bea488333ac38afcca4813b2c