### PR TITLE
fix: read generated image from nested data object

### DIFF
--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -96,11 +96,12 @@ function GeneratePromptImage(prompt)
         HideLoadingBar();
         const errEl = document.getElementById('aiGenerateError');
         if (data && data.success) {
-            croppedImageData = data.imgBase64;
+            const generatedImage = data.data.imgBase64;
+            croppedImageData = generatedImage;
             const img = document.getElementById('imageUploadPreview');
             if (img) {
                 img.onload = function() { InitCropper(); };
-                img.src = data.imgBase64;
+                img.src = generatedImage;
             }
             mediaUploadStep = 2;
             if (typeof UpdateMediaUploadModal === 'function') {


### PR DESCRIPTION
## Summary
- fix AI-generated image retrieval to read base64 string from nested data key in `GeneratePromptImage`

## Testing
- `php -l html/php-components/select-media.php`


------
https://chatgpt.com/codex/tasks/task_b_689964757c8c8333b252fd54aad185c6