### PR TITLE
Add AI image prompt editor to upload wizard

### DIFF
--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -181,13 +181,35 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                             <div class="input-group mb-3">
                                 <label class="input-group-text" for="inputMediaUploadPhoto"><i class="fa-solid fa-cloud-arrow-up"></i></label>
                                 <input type="file" class="form-control" id="inputMediaUploadPhoto" onchange="OnUploadFileChanged(this)">
-                                <button class="btn btn-secondary" type="button" onclick="PromptGenerateWithAI()">Generate with AI</button>
+                                <button class="btn btn-secondary" type="button" id="btnGenerateWithAI" onclick="PromptGenerateWithAI()">Generate with AI</button>
                             </div>
                         </div>
                     </div>
-                    <div class="row d-none" id="aiPromptInfo">
+                    <div class="row d-none" id="aiPromptEditor">
                         <div class="col-12">
-                            <p class="mb-1"><strong>Prompt:</strong> <span id="aiPromptText"></span></p>
+                            <div class="mb-3">
+                                <label for="imagePromptTemplate" class="form-label">Prompt Template</label>
+                                <select id="imagePromptTemplate" class="form-select">
+                                    <option value="">Select a template...</option>
+                                    <option value="lich card art">lich card art</option>
+                                    <option value="dragon card art">dragon card art</option>
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label for="imagePrompt" class="form-label">Prompt</label>
+                                <textarea id="imagePrompt" class="form-control" rows="3"></textarea>
+                            </div>
+                            <div class="mb-3">
+                                <label for="imageSize" class="form-label">Size</label>
+                                <select id="imageSize" class="form-select">
+                                    <option value="256x256">256x256</option>
+                                    <option value="512x512" selected>512x512</option>
+                                    <option value="1024x1024">1024x1024</option>
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <button class="btn btn-primary" type="button" onclick="GenerateImageFromPrompt()">Generate</button>
+                            </div>
                             <div id="aiGenerateError" class="alert alert-danger mt-2 d-none" role="alert"></div>
                         </div>
                     </div>

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -46,20 +46,29 @@ var pixelatedImageData = '';
 let cropper;
 let pixelEditor;
 let mediaUploadStep = 1;
-function PromptGenerateWithAI()
-{
-    const promptText = window.prompt('Enter a prompt for the image');
-    if (promptText) {
-        const info = document.getElementById('aiPromptInfo');
-        const promptLabel = document.getElementById('aiPromptText');
-        const errEl = document.getElementById('aiGenerateError');
-        promptLabel.textContent = promptText;
-        info.classList.remove('d-none');
-        errEl.classList.add('d-none');
-        errEl.textContent = '';
-        GeneratePromptImage(promptText);
+
+function PromptGenerateWithAI() {
+    const editor = document.getElementById('aiPromptEditor');
+    const btn = document.getElementById('btnGenerateWithAI');
+    if (editor) {
+        editor.classList.remove('d-none');
+    }
+    if (btn) {
+        btn.classList.add('d-none');
     }
 }
+
+window.addEventListener('DOMContentLoaded', () => {
+    const templateSelect = document.getElementById('imagePromptTemplate');
+    if (templateSelect) {
+        templateSelect.addEventListener('change', function() {
+            const textarea = document.getElementById('imagePrompt');
+            if (textarea) {
+                textarea.value = this.value;
+            }
+        });
+    }
+});
 
 function GeneratePromptImage(prompt)
 {
@@ -74,6 +83,7 @@ function GeneratePromptImage(prompt)
     const nameEl = document.getElementById('mediaUploadImageNameTextbox');
     const descEl = document.getElementById('mediaUploadImageDescTextbox');
     const promptEl = document.getElementById('imagePrompt');
+    const sizeEl = document.getElementById('imageSize');
     const sessionToken = "<?php echo $_SESSION["sessionToken"]; ?>";
 
     const formData = new URLSearchParams();
@@ -84,6 +94,7 @@ function GeneratePromptImage(prompt)
     if (directoryEl) { formData.append('directory', directoryEl.value); }
     if (nameEl) { formData.append('name', nameEl.value); }
     if (descEl) { formData.append('desc', descEl.value); }
+    if (sizeEl) { formData.append('size', sizeEl.value); }
     formData.append('sessionToken', sessionToken);
 
     fetch('/api/v1/media/generate.php', {


### PR DESCRIPTION
## Summary
- add prompt template, prompt textarea, size selector, and generate button to upload wizard step 1
- switch AI generation to use the new editor and template prefill, sending selected size

## Testing
- `php -l html/php-components/base-page-components.php`
- `php -l html/php-components/select-media.php`


------
https://chatgpt.com/codex/tasks/task_b_689965c801708333bc52dfed821cc050