### PR TITLE
feat: support custom image sizes

### DIFF
--- a/html/Kickback/Backend/Controllers/MediaController.php
+++ b/html/Kickback/Backend/Controllers/MediaController.php
@@ -247,7 +247,8 @@ class MediaController {
         string $prompt,
         string $directory,
         string $name,
-        string $desc
+        string $desc,
+        string $size = '1024x1024'
     ) : Response
     {
         $apiKey = \Kickback\Backend\Config\ServiceCredentials::get('openai_api_key');
@@ -263,7 +264,8 @@ class MediaController {
             $client = \OpenAI::client($apiKey);
             $result = $client->images()->create([
                 'prompt' => $prompt,
-                'response_format' => 'b64_json'
+                'response_format' => 'b64_json',
+                'size' => $size,
             ]);
 
             $b64 = $result['data'][0]['b64_json'] ?? '';

--- a/html/api/v1/engine/media/generate.php
+++ b/html/api/v1/engine/media/generate.php
@@ -9,7 +9,7 @@ use Kickback\Backend\Config\ServiceCredentials;
 
 OnlyPOST();
 
-$containsFieldsResp = POSTContainsFields("prompt","directory","name","desc","sessionToken");
+$containsFieldsResp = POSTContainsFields("prompt","directory","name","desc","sessionToken","size");
 if (!$containsFieldsResp->success)
     return $containsFieldsResp;
 
@@ -20,6 +20,7 @@ $directory = Validate($_POST["directory"]);
 $name = Validate($_POST["name"]);
 $desc = Validate($_POST["desc"]);
 $sessionToken = Validate($_POST["sessionToken"]);
+$size = Validate($_POST["size"]);
 
 $loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
 if (!$loginResp->success)
@@ -27,5 +28,5 @@ if (!$loginResp->success)
     return $loginResp;
 }
 
-return MediaController::GenerateImage($prompt, $directory, $name, $desc);
+return MediaController::GenerateImage($prompt, $directory, $name, $desc, $size);
 ?>

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -94,7 +94,9 @@ function GeneratePromptImage(prompt)
     if (directoryEl) { formData.append('directory', directoryEl.value); }
     if (nameEl) { formData.append('name', nameEl.value); }
     if (descEl) { formData.append('desc', descEl.value); }
-    if (sizeEl) { formData.append('size', sizeEl.value); }
+    if (sizeEl && sizeEl.value) {
+        formData.append('size', sizeEl.value);
+    }
     formData.append('sessionToken', sessionToken);
 
     fetch('/api/v1/media/generate.php', {


### PR DESCRIPTION
## Summary
- allow users to specify image size in prompt generation
- wire size through generate API
- send size parameter to OpenAI image creation

## Testing
- `./meta/phpstan.sh` *(fails: Could not open input file: ./meta/../html/vendor/composer/phpstan/phpstan/phpstan)*
- `composer install` *(fails: Required package "openai-php/client" is not present in the lock file)*
- `composer update openai-php/client` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_689967c33da883338adb3e192ba54df0