### PR TITLE
feat: allow model selection for AI image generation

### DIFF
--- a/html/Kickback/Backend/Controllers/MediaController.php
+++ b/html/Kickback/Backend/Controllers/MediaController.php
@@ -248,7 +248,8 @@ class MediaController {
         string $directory,
         string $name,
         string $desc,
-        string $size = '1024x1024'
+        string $size = '1024x1024',
+        string $model = 'gpt-image-1'
     ) : Response
     {
         $apiKey = \Kickback\Backend\Config\ServiceCredentials::get('openai_api_key');
@@ -263,6 +264,7 @@ class MediaController {
         try {
             $client = \OpenAI::client($apiKey);
             $result = $client->images()->create([
+                'model' => $model,
                 'prompt' => $prompt,
                 'response_format' => 'b64_json',
                 'size' => $size,

--- a/html/Kickback/Backend/Controllers/MediaController.php
+++ b/html/Kickback/Backend/Controllers/MediaController.php
@@ -266,7 +266,6 @@ class MediaController {
             $result = $client->images()->create([
                 'model' => $model,
                 'prompt' => $prompt,
-                'response_format' => 'b64_json',
                 'size' => $size,
             ]);
 

--- a/html/Kickback/Backend/Controllers/MediaController.php
+++ b/html/Kickback/Backend/Controllers/MediaController.php
@@ -261,6 +261,16 @@ class MediaController {
             return new Response(false, 'OpenAI client library not installed.', null);
         }
 
+        $allowedSizes = [
+            'gpt-image-1' => ['1024x1024', '1024x1536', '1536x1024', 'auto'],
+            'dall-e-2'   => ['256x256', '512x512', '1024x1024'],
+        ];
+
+        if (isset($allowedSizes[$model]) && !in_array($size, $allowedSizes[$model], true)) {
+            $supported = implode("', '", $allowedSizes[$model]);
+            return new Response(false, "Invalid value: '$size'. Supported values are: '$supported'.", null);
+        }
+
         try {
             $client = \OpenAI::client($apiKey);
             $result = $client->images()->create([

--- a/html/Kickback/Backend/Controllers/MediaController.php
+++ b/html/Kickback/Backend/Controllers/MediaController.php
@@ -273,11 +273,17 @@ class MediaController {
 
         try {
             $client = \OpenAI::client($apiKey);
-            $result = $client->images()->create([
+            $params = [
                 'model' => $model,
                 'prompt' => $prompt,
                 'size' => $size,
-            ]);
+            ];
+
+            if ($model === 'dall-e-2') {
+                $params['response_format'] = 'b64_json';
+            }
+
+            $result = $client->images()->create($params);
 
             $b64 = $result['data'][0]['b64_json'] ?? '';
             if (Str::empty($b64)) {

--- a/html/api/v1/engine/media/generate.php
+++ b/html/api/v1/engine/media/generate.php
@@ -9,7 +9,7 @@ use Kickback\Backend\Config\ServiceCredentials;
 
 OnlyPOST();
 
-$containsFieldsResp = POSTContainsFields("prompt","directory","name","desc","sessionToken","size");
+$containsFieldsResp = POSTContainsFields("prompt","directory","name","desc","sessionToken","size","model");
 if (!$containsFieldsResp->success)
     return $containsFieldsResp;
 
@@ -21,6 +21,7 @@ $name = Validate($_POST["name"]);
 $desc = Validate($_POST["desc"]);
 $sessionToken = Validate($_POST["sessionToken"]);
 $size = Validate($_POST["size"]);
+$model = Validate($_POST["model"]);
 
 $loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
 if (!$loginResp->success)
@@ -28,5 +29,5 @@ if (!$loginResp->success)
     return $loginResp;
 }
 
-return MediaController::GenerateImage($prompt, $directory, $name, $desc, $size);
+return MediaController::GenerateImage($prompt, $directory, $name, $desc, $size, $model);
 ?>

--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -208,6 +208,13 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                 </select>
                             </div>
                             <div class="mb-3">
+                                <label for="imageModel" class="form-label">Model</label>
+                                <select id="imageModel" class="form-select">
+                                    <option value="gpt-image-1" selected>gpt-image-1</option>
+                                    <option value="dall-e-2">dall-e-2</option>
+                                </select>
+                            </div>
+                            <div class="mb-3">
                                 <button class="btn btn-primary" type="button" onclick="GenerateImageFromPrompt()">Generate</button>
                             </div>
                             <div id="aiGenerateError" class="alert alert-danger mt-2 d-none" role="alert"></div>

--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -202,9 +202,10 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                             <div class="mb-3">
                                 <label for="imageSize" class="form-label">Size</label>
                                 <select id="imageSize" class="form-select">
-                                    <option value="256x256">256x256</option>
-                                    <option value="512x512" selected>512x512</option>
-                                    <option value="1024x1024">1024x1024</option>
+                                    <option value="1024x1024" selected>1024x1024</option>
+                                    <option value="1024x1536">1024x1536</option>
+                                    <option value="1536x1024">1536x1024</option>
+                                    <option value="auto">auto</option>
                                 </select>
                             </div>
                             <div class="mb-3">

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -84,6 +84,7 @@ function GeneratePromptImage(prompt)
     const descEl = document.getElementById('mediaUploadImageDescTextbox');
     const promptEl = document.getElementById('imagePrompt');
     const sizeEl = document.getElementById('imageSize');
+    const modelEl = document.getElementById('imageModel');
     const sessionToken = "<?php echo $_SESSION["sessionToken"]; ?>";
 
     const formData = new URLSearchParams();
@@ -96,6 +97,9 @@ function GeneratePromptImage(prompt)
     if (descEl) { formData.append('desc', descEl.value); }
     if (sizeEl && sizeEl.value) {
         formData.append('size', sizeEl.value);
+    }
+    if (modelEl && modelEl.value) {
+        formData.append('model', modelEl.value);
     }
     formData.append('sessionToken', sessionToken);
 

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -68,6 +68,40 @@ window.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    const modelSelect = document.getElementById('imageModel');
+    const sizeSelect = document.getElementById('imageSize');
+    if (modelSelect && sizeSelect) {
+        const sizeOptions = {
+            'gpt-image-1': [
+                '1024x1024',
+                '1024x1536',
+                '1536x1024',
+                'auto'
+            ],
+            'dall-e-2': [
+                '1024x1024',
+                '512x512',
+                '256x256'
+            ]
+        };
+
+        const renderSizeOptions = (model) => {
+            sizeSelect.innerHTML = '';
+            (sizeOptions[model] || []).forEach(value => {
+                const opt = document.createElement('option');
+                opt.value = value;
+                opt.textContent = value;
+                sizeSelect.appendChild(opt);
+            });
+        };
+
+        modelSelect.addEventListener('change', () => {
+            renderSizeOptions(modelSelect.value);
+        });
+
+        renderSizeOptions(modelSelect.value);
+    }
 });
 
 function GeneratePromptImage(prompt)


### PR DESCRIPTION
## Summary
- Add model dropdown to AI image uploader
- Pipe chosen model through frontend and backend
- Pass selected model to OpenAI image generation request

## Testing
- `php -l html/php-components/base-page-components.php`
- `php -l html/php-components/select-media.php`
- `php -l html/api/v1/engine/media/generate.php`
- `php -l html/Kickback/Backend/Controllers/MediaController.php`


------
https://chatgpt.com/codex/tasks/task_b_689963c60f988333a2f65200b79567c1