### PR TITLE
Add description field for AI image prompt

### DIFF
--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -200,6 +200,10 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                 <textarea id="imagePrompt" class="form-control" rows="3"></textarea>
                             </div>
                             <div class="mb-3">
+                                <label for="imagePromptDescription" class="form-label">Description</label>
+                                <textarea id="imagePromptDescription" class="form-control" rows="2"></textarea>
+                            </div>
+                            <div class="mb-3">
                                 <label for="imageSize" class="form-label">Size</label>
                                 <select id="imageSize" class="form-select">
                                     <option value="1024x1024" selected>1024x1024</option>


### PR DESCRIPTION
## Summary
- add Description textarea with unique ID `imagePromptDescription` next to AI image prompt

## Testing
- `composer test` (fails: Command "test" is not defined)
- `php -l html/php-components/base-page-components.php`


------
https://chatgpt.com/codex/tasks/task_b_6899db30b75c8333ad9d3828cf40e04e