### PR TITLE
Preserve manual prompt edits

### DIFF
--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -45,6 +45,7 @@ const promptTemplates = {
     Modern clothing & props. ${desc}`
 };
 
+let promptDirty = false;
 
 let currentSelectMediaPage = 1; // default page
 const itemsPerSelectMediaPage = 6; // or however many you want
@@ -79,7 +80,16 @@ function updatePromptPreview() {
         ? promptTemplates[template](description)
         : description;
     if (promptEl) {
-        promptEl.value = finalPrompt;
+        if (template) {
+            promptEl.value = finalPrompt;
+            promptEl.readOnly = true;
+            promptDirty = false;
+        } else {
+            promptEl.readOnly = false;
+            if (!promptDirty) {
+                promptEl.value = finalPrompt;
+            }
+        }
     }
 }
 
@@ -91,6 +101,11 @@ window.addEventListener('DOMContentLoaded', () => {
     const descriptionEl = document.getElementById('imagePromptDescription');
     if (descriptionEl) {
         descriptionEl.addEventListener('input', updatePromptPreview);
+    }
+
+    const promptEl = document.getElementById('imagePrompt');
+    if (promptEl) {
+        promptEl.addEventListener('input', () => promptDirty = true);
     }
 
     const modelSelect = document.getElementById('imageModel');


### PR DESCRIPTION
## Summary
- lock prompt input when a template is selected
- preserve manual prompts and avoid overwriting when description updates

## Testing
- `php -l html/php-components/select-media.php`
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6899f824461c8333b6ada06fa2f764f8