### PR TITLE
Enhance color glow with global multiplier

### DIFF
--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -364,6 +364,10 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                             <label class="form-label">Bloom Threshold</label>
                                             <input type="range" class="form-range" data-bloom-threshold min="0" max="255" value="200">
                                         </div>
+                                        <div class="mb-2">
+                                            <label class="form-label">Global Glow Multiplier</label>
+                                            <input type="range" class="form-range" data-glow-all min="0" max="300" value="100">
+                                        </div>
                                         <div class="mb-3">
                                             <label class="form-label">Reds</label>
                                             <div class="row g-1">


### PR DESCRIPTION
## Summary
- Scale color glow strength quadratically and add a global multiplier option
- Expose global glow multiplier control in pixel editor UI

## Testing
- `node --check html/assets/js/pixel-editor.js`
- `php -l html/php-components/base-page-components.php`


------
https://chatgpt.com/codex/tasks/task_b_689a4a2dd4ac833380176e4c13cdf721