### PR TITLE
Use linear glow strength in pixel editor

### DIFF
--- a/html/assets/js/pixel-editor.js
+++ b/html/assets/js/pixel-editor.js
@@ -137,7 +137,7 @@ function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.n
         const hsl=rgbToHsl(r,g,bl);
         const b=nearestBucket(hsl.h);
         if(b!==bandKey || hsl.l<=threshold){ d[i]=d[i+1]=d[i+2]=0; continue; }
-        const eff=strength*strength;
+        const eff=strength;
         const newL=Math.min(1, hsl.l+eff);
         const newS=Math.min(1, hsl.s+eff);
         const rgb=hslToRgb(hsl.h,newS,newL);
@@ -147,6 +147,7 @@ function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.n
       ctx.save();
       if(range>0) ctx.filter=`blur(${range}px)`;
       ctx.globalCompositeOperation='lighter';
+      ctx.globalAlpha=Math.min(1, strength);
       ctx.drawImage(off,0,0);
       ctx.restore();
     }


### PR DESCRIPTION
## Summary
- Switch color glow effect to linear strength mapping
- Scale glow overlay intensity by strength for smoother transitions

## Testing
- `npm test` *(fails: Could not find package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_689a599c03fc8333a4fbe2f272dbebcb