### PR TITLE
Expose pixel editor instance globally

### DIFF
--- a/html/assets/js/pixel-editor.js
+++ b/html/assets/js/pixel-editor.js
@@ -813,7 +813,7 @@ function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.n
         }
       }
 
-      return {
+      const api = {
         render,
         setImage: (image)=>{ img=image; collectSettings(); render(); },
         destroy,
@@ -824,6 +824,9 @@ function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.n
         updateLayer,
         setLayerEnabled
       };
+      // Expose the editor instance globally so other scripts can access it
+      window.pixelEditor = api;
+      return api;
     }
 
 export { applyAdjustments, applyColorTuning, applyHueRemap, applyColorGlow, applyBloom, kmeansRGB, floydSteinbergQuantize };


### PR DESCRIPTION
## Summary
- Set `window.pixelEditor` inside `initPixelEditor` so other scripts can access the editor API

## Testing
- `node --check html/assets/js/pixel-editor.js`


------
https://chatgpt.com/codex/tasks/task_b_689a78b4f70083338611c327c3486484