### PR TITLE
Soften pixel editor glow and bloom controls

### DIFF
--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -451,7 +451,7 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                             <div>
                                                 <div class="mb-2">
                                                     <label class="form-label">Bloom Alpha</label>
-                                                    <input type="range" class="form-range" data-field="alpha" min="0" max="100" value="0">
+                                                    <input type="range" class="form-range" data-field="alpha" min="0" max="1" step="0.01" value="0">
                                                 </div>
                                                 <div class="mb-2">
                                                 <label class="form-label">Bloom Blur</label>


### PR DESCRIPTION
## Summary
- Ease color-glow strength quadratically and square lightness threshold for smoother falloff
- Normalize bloom alpha to 0–1 range and ease overlay with a quartic curve

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_689a81089e488333907dd75143080bee