### PR TITLE
Sync Color Glow UI with layer defaults

### DIFF
--- a/html/assets/js/pixel-editor.js
+++ b/html/assets/js/pixel-editor.js
@@ -148,11 +148,11 @@ function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.n
    * @param {CanvasRenderingContext2D} ctx
    * @param {number} w - canvas width
    * @param {number} h - canvas height
-   * @param {Object} glows - map of hue buckets to strength/range
-  * @param {number} [threshold=0.6] - minimum lightness [0-1] required for glow
-  * @param {number} [globalMult=1] - multiplier applied to all band strengths
-   */
-  function applyColorGlow(ctx, w, h, glows, threshold=0.6, globalMult=1){
+ * @param {Object} glows - map of hue buckets to strength/range
+ * @param {number} [threshold=0] - minimum lightness [0-1] required for glow
+ * @param {number} [globalMult=1] - multiplier applied to all band strengths
+ */
+  function applyColorGlow(ctx, w, h, glows, threshold=0, globalMult=1){
     if(!glows || !Object.values(glows).some(v=>v.s>0)) return;
     for(const [bandKey, cfg] of Object.entries(glows)){
       const strength=(cfg.s||0)*globalMult;
@@ -491,12 +491,11 @@ function throttled(ms, fn){ let last=0, timer; return (...a)=>{ const now=Date.n
         if(gGRange) gGRange.value = glow.options.glowMap.G.r ?? d.glowMap.G.r;
         if(gCRange) gCRange.value = glow.options.glowMap.C.r ?? d.glowMap.C.r;
         if(gBRange) gBRange.value = glow.options.glowMap.B.r ?? d.glowMap.B.r;
-        if(gMRange) gMRange.value = glow.options.glowMap.M.r ?? d.glowMap.M.r;
-      } else {
-        const d = LAYER_DEFAULTS.colorGlow();
-        if(enableGlow) enableGlow.checked = settings?.enableGlow ?? false;
-        if(enableGlow) enableGlow.checked = settings?.enableGlow ?? false;
-        if(glowThreshold) glowThreshold.value = settings?.glowThreshold ?? d.threshold;
+      if(gMRange) gMRange.value = glow.options.glowMap.M.r ?? d.glowMap.M.r;
+    } else {
+      const d = LAYER_DEFAULTS.colorGlow();
+      if(enableGlow) enableGlow.checked = settings?.enableGlow ?? false;
+      if(glowThreshold) glowThreshold.value = settings?.glowThreshold ?? d.threshold;
         if(gAll) gAll.value = settings?.glow?.global ?? d.global;
         if(gR) gR.value = settings?.glow?.R?.strength ?? d.glowMap.R.s;
         if(gY) gY.value = settings?.glow?.Y?.strength ?? d.glowMap.Y.s;

--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -555,7 +555,7 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                 <script>
                 const layerDefaults = window.LAYER_DEFAULTS || {
                     adjustments: () => ({brightness:0, contrast:0, saturation:100}),
-                    colorGlow: () => ({threshold:60, global:100, glowMap:{R:{s:0,r:10},Y:{s:0,r:10},G:{s:0,r:10},C:{s:0,r:10},B:{s:0,r:10},M:{s:0,r:10}}}),
+                    colorGlow: () => ({threshold:0, global:100, glowMap:{R:{s:0,r:10},Y:{s:0,r:10},G:{s:0,r:10},C:{s:0,r:10},B:{s:0,r:10},M:{s:0,r:10}}}),
                     bloom: () => ({alpha:90, blur:4, threshold:33}),
                     tune: () => ({R:0,Y:0,G:0,C:0,B:0,M:0}),
                     remap: () => ({globalStrength:100, mapping:{R:{t:0,s:1},Y:{t:0,s:1},G:{t:0,s:1},C:{t:0,s:1},B:{t:0,s:1},M:{t:0,s:1}}})


### PR DESCRIPTION
## Summary
- Default Color Glow lightness threshold to 0 in layer settings
- Match layer defaults in fallback UI setup for pixel editor

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_b_689aa56b2edc8333ba541009de7d9369