### PR TITLE
Use icons for pixel editor layer tabs

### DIFF
--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -677,6 +677,13 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                     }
 
                     function refreshUI(activeIndex=null){
+                        const layerIcons={
+                            adjustments:'fa-sliders',
+                            colorGlow:'fa-fire',
+                            bloom:'fa-sun',
+                            tune:'fa-wrench',
+                            remap:'fa-arrows-rotate'
+                        };
                         const currentActive=layerTabs.querySelector('.nav-link.active');
                         if(activeIndex===null && currentActive){
                             activeIndex=parseInt(currentActive.getAttribute('data-layer-index'),10);
@@ -708,9 +715,10 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                             tab.role='tab';
                             tab.setAttribute('aria-controls',`pixelPaneLayer${i}`);
                             tab.setAttribute('aria-selected','false');
-                            tab.textContent=layer.type;
+                            tab.innerHTML=`<i class="fa-solid ${layerIcons[layer.type]}" title="${layer.type}" aria-label="${layer.type}"></i>`;
                             tab.setAttribute('data-layer-index',i);
                             layerTabs.appendChild(tab);
+                            bootstrap.Tab.getOrCreateInstance(tab);
 
                             const pane=renderLayerPane(layer,i);
                             layerTabContent.appendChild(pane);


### PR DESCRIPTION
## Summary
- display pixel layer tabs with Font Awesome icons instead of text
- initialize Bootstrap tabs after dynamically creating them

## Testing
- `php -l html/php-components/base-page-components.php`
- `composer validate` *(fails: lock file not up to date)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ab05d8d90833394d9605a2c3dcabd