### PR TITLE
Style LICH rulebook and highlight search matches

### DIFF
--- a/html/assets/css/lich-rulebook.css
+++ b/html/assets/css/lich-rulebook.css
@@ -3,3 +3,41 @@
 #rulebook-container {
     /* Rule content will be inserted dynamically */
 }
+
+/* Section and page layout */
+#rulebook-container section {
+    margin-bottom: 2rem;
+}
+
+#rulebook-container article.rulebook-page {
+    margin-bottom: 1.5rem;
+}
+
+#rulebook-container h2,
+#rulebook-container h3,
+#rulebook-container h4 {
+    margin-top: 1.5rem;
+    margin-bottom: 1rem;
+    font-weight: 700;
+}
+
+#rulebook-container p,
+#rulebook-container ol {
+    margin-bottom: 1rem;
+}
+
+/* Responsive images and diagrams */
+#rulebook-container img,
+#rulebook-container svg {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 1rem auto;
+}
+
+/* Highlight for search matches */
+.search-highlight {
+    background-color: #fff3cd;
+    padding: 0 0.2em;
+}
+

--- a/html/assets/js/lich-rulebook.js
+++ b/html/assets/js/lich-rulebook.js
@@ -78,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 pageEl.dataset.tags = Array.from(tagSet).join(' ').toLowerCase();
+                pageEl.dataset.original = pageEl.innerHTML;
                 sectionEl.appendChild(pageEl);
             });
 
@@ -91,9 +92,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const pages = container.querySelectorAll('.rulebook-page');
 
         pages.forEach((page) => {
+            // Reset page content to original to remove previous highlights
+            page.innerHTML = page.dataset.original;
+
             const text = page.textContent.toLowerCase();
             const tags = page.dataset.tags || '';
-            page.style.display = text.includes(term) || tags.includes(term) ? '' : 'none';
+
+            if (text.includes(term) || tags.includes(term)) {
+                page.style.display = '';
+
+                if (term) {
+                    const regex = new RegExp(`(${term})`, 'gi');
+                    page.innerHTML = page.innerHTML.replace(regex, '<span class="search-highlight">$1</span>');
+                }
+            } else {
+                page.style.display = 'none';
+            }
         });
     });
 });

--- a/html/lich-rulebook.php
+++ b/html/lich-rulebook.php
@@ -12,9 +12,8 @@ use Kickback\Common\Version;
 ob_start();
 require("php-components/base-page-head.php");
 $baseHead = ob_get_clean();
-$cssFile = Version::urlBetaPrefix().'/assets/css/lich-rulebook.css';
-$cssVersion = Version::current()->number();
-$baseHead = str_replace('</head>', '<link rel="stylesheet" type="text/css" href="'.$cssFile.'?v='.$cssVersion.'"></head>', $baseHead);
+$cssHref = Version::urlBetaPrefix().'/assets/css/lich-rulebook.css?v='.Version::current()->number();
+$baseHead = str_replace('</head>', '<link rel="stylesheet" href="'.$cssHref.'"></head>', $baseHead);
 echo $baseHead;
 ?>
 <body class="bg-body-secondary container p-0">


### PR DESCRIPTION
## Summary
- add dedicated stylesheet for LICH rulebook with layout, responsive images, and highlight classes
- highlight search term matches in rulebook JavaScript and store original content for reset
- load rulebook stylesheet in PHP with cache-busting URL using `Version::urlBetaPrefix`

## Testing
- `php -l html/lich-rulebook.php`
- `node --check html/assets/js/lich-rulebook.js`


------
https://chatgpt.com/codex/tasks/task_b_689bad060dfc8333b78f34fbee3d24b4