### PR TITLE
Add rulebook section icons

### DIFF
--- a/html/assets/css/lich-rulebook.css
+++ b/html/assets/css/lich-rulebook.css
@@ -97,3 +97,11 @@
     padding: 0 0.2em;
 }
 
+/* Section icons */
+#rulebook-container .section-icon {
+    width: 32px;
+    height: 32px;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+}
+

--- a/html/assets/data/lich-rulebook.json
+++ b/html/assets/data/lich-rulebook.json
@@ -1,782 +1,2196 @@
 {
-    "meta": {
-      "game": "L.I.C.H.",
-      "rulebookVersion": "0.5.8-alpha",
-      "schemaVersion": "1.0.0",
-      "lastUpdated": "2025-08-12",
-      "copyright": "© L.I.C.H.",
-      "license": "All rights reserved"
+  "meta": {
+    "game": "L.I.C.H.",
+    "rulebookVersion": "0.5.8-alpha",
+    "schemaVersion": "1.0.0",
+    "lastUpdated": "2025-08-12",
+    "copyright": "© L.I.C.H.",
+    "license": "All rights reserved"
+  },
+  "assets": {
+    "imagesBase": "images/lich/",
+    "iconsBase": "images/icons/",
+    "diagramsBase": "images/lich/diagrams/"
+  },
+  "sections": [
+    {
+      "id": "intro",
+      "slug": "introduction",
+      "title": "Introduction",
+      "pages": [
+        {
+          "id": "welcome",
+          "slug": "welcome",
+          "title": "Welcome to the L.I.C.H. Rulebook",
+          "body": [
+            "L.I.C.H. is a tactical board & card game played on a hex grid with heroes (Avatars), summons, surfaces, and source-driven cards.",
+            "<p><strong>Readability tip:</strong> Each numbered rule is linkable; hover the link icon to copy a direct URL.</p>"
+          ],
+          "figures": [
+            {
+              "id": "fig-overview",
+              "src": "images/lich/overview.png",
+              "caption": "High-level components of L.I.C.H.",
+              "alt": "Overview diagram of board zones, avatars, and action zones"
+            }
+          ],
+          "tags": [
+            "overview",
+            "getting-started"
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
     },
-    "assets": {
-      "imagesBase": "images/lich/",
-      "iconsBase": "images/icons/",
-      "diagramsBase": "images/lich/diagrams/"
+    {
+      "id": "game-setup",
+      "slug": "game-setup",
+      "title": "Game Setup",
+      "pages": [
+        {
+          "id": "board",
+          "slug": "the-board",
+          "title": "The Board",
+          "rules": [
+            {
+              "rid": "BRD-001",
+              "text": "The game uses a hexagonal board with a hex grid; each side has 6 hexes.",
+              "tags": [
+                "board",
+                "dimensions"
+              ]
+            },
+            {
+              "rid": "BRD-002",
+              "text": "Starting positions are the six corners of the board.",
+              "tags": [
+                "board",
+                "starting-positions"
+              ]
+            }
+          ],
+          "subsections": [
+            {
+              "title": "Source Stones",
+              "rules": [
+                {
+                  "rid": "BP-SRC-001",
+                  "text": "Source Stones are placed on the board before play.",
+                  "tags": [
+                    "source-stones",
+                    "setup"
+                  ]
+                },
+                {
+                  "rid": "BP-SRC-002",
+                  "text": "When an Avatar occupies a Source Stone tile, its controller must draw 1 pure source if able.",
+                  "tags": [
+                    "source-stones",
+                    "draw"
+                  ]
+                },
+                {
+                  "rid": "BP-SRC-003",
+                  "text": "Summons treat Source Stones as walls except for line of sight.",
+                  "tags": [
+                    "source-stones",
+                    "walls",
+                    "line-of-sight"
+                  ]
+                },
+                {
+                  "rid": "BP-SRC-004",
+                  "text": "Source Stones do not impede line of sight.",
+                  "tags": [
+                    "source-stones",
+                    "line-of-sight"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Walls",
+              "rules": [
+                {
+                  "rid": "BP-WAL-001",
+                  "text": "Avatars and Summons may not occupy wall tiles.",
+                  "tags": [
+                    "walls"
+                  ]
+                },
+                {
+                  "rid": "BP-WAL-002",
+                  "text": "Walls block line of sight.",
+                  "tags": [
+                    "walls",
+                    "line-of-sight"
+                  ]
+                },
+                {
+                  "rid": "BP-WAL-003",
+                  "text": "Walls are placed according to map setup before play.",
+                  "tags": [
+                    "walls",
+                    "setup"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Avatars",
+              "rules": [
+                {
+                  "rid": "BP-AVA-001",
+                  "text": "Avatars represent their controller’s hero on the board.",
+                  "tags": [
+                    "avatars"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Summon Pieces",
+              "rules": [
+                {
+                  "rid": "BP-SUM-001",
+                  "text": "Summon pieces come in pairs of matching design or color.",
+                  "tags": [
+                    "summons",
+                    "components"
+                  ]
+                },
+                {
+                  "rid": "BP-SUM-002",
+                  "text": "One piece marks the summoned target on the board and the other marks its summoning card, linking them.",
+                  "tags": [
+                    "summons",
+                    "components"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Surface Tiles",
+              "rules": [
+                {
+                  "rid": "BP-SFC-001",
+                  "text": "Surface tiles are placed on the board to represent the surface occupying that tile.",
+                  "tags": [
+                    "surfaces"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Fields",
+              "rules": [
+                {
+                  "rid": "FZ-FIELD-001",
+                  "text": "Each player has a field containing their cards and deck.",
+                  "tags": [
+                    "field"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Action Zone",
+              "rules": [
+                {
+                  "rid": "FZ-ACT-001",
+                  "text": "The action zone consists of 5 action slots.",
+                  "tags": [
+                    "action-zone"
+                  ]
+                },
+                {
+                  "rid": "FZ-ACT-002",
+                  "text": "Each slot may hold one action card.",
+                  "tags": [
+                    "action-zone"
+                  ]
+                },
+                {
+                  "rid": "FZ-ACT-003",
+                  "text": "The action zone is public knowledge at all times.",
+                  "tags": [
+                    "action-zone",
+                    "public-info"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Deck",
+              "rules": [
+                {
+                  "rid": "FZ-DECK-001",
+                  "text": "The deck is where cards are drawn from, especially at the end of each turn.",
+                  "tags": [
+                    "deck"
+                  ]
+                },
+                {
+                  "rid": "FZ-DECK-002",
+                  "text": "The deck is kept face down and not freely searchable.",
+                  "tags": [
+                    "deck",
+                    "hidden-info"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Purgatory",
+              "rules": [
+                {
+                  "rid": "FZ-PUR-001",
+                  "text": "Destroyed, discarded, or attrited cards go to the controller’s Purgatory.",
+                  "tags": [
+                    "purgatory"
+                  ]
+                },
+                {
+                  "rid": "FZ-PUR-002",
+                  "text": "All purgatories are public knowledge at all times.",
+                  "tags": [
+                    "purgatory",
+                    "public-info"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Abyss",
+              "rules": [
+                {
+                  "rid": "FZ-ABY-001",
+                  "text": "Damned or offered cards go to the controller’s Abyss.",
+                  "tags": [
+                    "abyss"
+                  ]
+                },
+                {
+                  "rid": "FZ-ABY-002",
+                  "text": "All abysses are public knowledge at all times.",
+                  "tags": [
+                    "abyss",
+                    "public-info"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Hero Zone",
+              "rules": [
+                {
+                  "rid": "FZ-HRZ-001",
+                  "text": "The Hero zone holds a player's Hero card.",
+                  "tags": [
+                    "hero-zone"
+                  ]
+                },
+                {
+                  "rid": "FZ-HRZ-002",
+                  "text": "All Hero zones are public knowledge at all times.",
+                  "tags": [
+                    "hero-zone",
+                    "public-info"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "The Hand",
+              "rules": [
+                {
+                  "rid": "FZ-HAND-001",
+                  "text": "Each player’s hand is private to non‑teammates.",
+                  "tags": [
+                    "hand",
+                    "hidden-info"
+                  ]
+                }
+              ]
+            }
+          ],
+          "figures": [
+            {
+              "id": "fig-board-labeled",
+              "src": "images/lich/diagrams/board-labeled.png",
+              "caption": "Board with corners, zones, and example walls.",
+              "alt": "Hex board with marked corners and zones"
+            }
+          ],
+          "tags": [
+            "setup",
+            "board",
+            "zones"
+          ]
+        },
+        {
+          "id": "initialization",
+          "slug": "initialization",
+          "title": "Initialization",
+          "subsections": [
+            {
+              "title": "Board Setup",
+              "rules": [
+                {
+                  "rid": "INI-SETUP-001",
+                  "text": "The board is set up according to the to-be-played map.",
+                  "tags": [
+                    "setup",
+                    "board"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Offering to the Lich",
+              "rules": [
+                {
+                  "rid": "OFF-001",
+                  "text": "Base Offering: Each player draws 3, chooses 1 to offer (face‑down), then reveal. Highest total source cost goes first; turn order clockwise.",
+                  "tags": [
+                    "offering",
+                    "turn-order"
+                  ]
+                },
+                {
+                  "rid": "OFF-002",
+                  "text": "Tie breaker: Tied players reshuffle, redraw 3, choose again; reveal and compare.",
+                  "tags": [
+                    "offering",
+                    "tie-breaker"
+                  ]
+                },
+                {
+                  "rid": "OFF-003",
+                  "text": "Sudden Death: If still tied, tied players reveal cards from top of deck until a winner emerges.",
+                  "tags": [
+                    "offering",
+                    "sudden-death"
+                  ]
+                },
+                {
+                  "rid": "OFF-004",
+                  "text": "End of Offering: The chosen card is put into its controller’s Abyss; all other cards are shuffled back. Players do not draw initial hands yet.",
+                  "tags": [
+                    "offering",
+                    "abyss"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Choosing Starting Positions",
+              "rules": [
+                {
+                  "rid": "STP-001",
+                  "text": "In turn order, each player picks an Avatar and places it on a starting corner.",
+                  "tags": [
+                    "starting-positions"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Initial Hand Draw",
+              "rules": [
+                {
+                  "rid": "DRW-001",
+                  "text": "Initial hands are drawn after Avatars are placed.",
+                  "tags": [
+                    "initial-draw"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Mulligans",
+              "rules": [
+                {
+                  "rid": "MUL-001",
+                  "text": "Return your entire hand to your deck, redraw that many cards, then discard 1 card for each mulligan after the first.",
+                  "tags": [
+                    "mulligan"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "End Initialization",
+              "rules": [
+                {
+                  "rid": "INI-END-001",
+                  "text": "After all players have drawn their hands and finished Mulligans, the game begins.",
+                  "tags": [
+                    "start-game"
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags": [
+            "setup",
+            "offering",
+            "mulligan"
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
     },
-    "sections": [
-      {
-        "id": "intro",
-        "slug": "introduction",
-        "title": "Introduction",
-        "pages": [
-          {
-            "id": "welcome",
-            "slug": "welcome",
-            "title": "Welcome to the L.I.C.H. Rulebook",
-            "body": [
-              "L.I.C.H. is a tactical board & card game played on a hex grid with heroes (Avatars), summons, surfaces, and source-driven cards.",
-              "<p><strong>Readability tip:</strong> Each numbered rule is linkable; hover the link icon to copy a direct URL.</p>"
-            ],
-            "figures": [
-              {
-                "id": "fig-overview",
-                "src": "images/lich/overview.png",
-                "caption": "High-level components of L.I.C.H.",
-                "alt": "Overview diagram of board zones, avatars, and action zones"
-              }
-            ],
-            "tags": ["overview", "getting-started"]
-          }
-        ]
-      },
-  
-      {
-        "id": "game-setup",
-        "slug": "game-setup",
-        "title": "Game Setup",
-        "pages": [
-          {
-            "id": "board",
-            "slug": "the-board",
-            "title": "The Board",
-            "rules": [
-              {
-                "rid": "BRD-001",
-                "text": "The game uses a hexagonal board with a hex grid; each side has 6 hexes.",
-                "tags": ["board", "dimensions"]
-              },
-              {
-                "rid": "BRD-002",
-                "text": "Starting positions are the six corners of the board.",
-                "tags": ["board", "starting-positions"]
-              }
-            ],
-            "subsections": [
-              {
-                "title": "Source Stones",
-                "rules": [
-                  { "rid": "BP-SRC-001", "text": "Source Stones are placed on the board before play.", "tags": ["source-stones", "setup"] },
-                  { "rid": "BP-SRC-002", "text": "When an Avatar occupies a Source Stone tile, its controller must draw 1 pure source if able.", "tags": ["source-stones", "draw"] },
-                  { "rid": "BP-SRC-003", "text": "Summons treat Source Stones as walls except for line of sight.", "tags": ["source-stones", "walls", "line-of-sight"] },
-                  { "rid": "BP-SRC-004", "text": "Source Stones do not impede line of sight.", "tags": ["source-stones", "line-of-sight"] }
-                ]
-              },
-              {
-                "title": "Walls",
-                "rules": [
-                  { "rid": "BP-WAL-001", "text": "Avatars and Summons may not occupy wall tiles.", "tags": ["walls"] },
-                  { "rid": "BP-WAL-002", "text": "Walls block line of sight.", "tags": ["walls", "line-of-sight"] },
-                  { "rid": "BP-WAL-003", "text": "Walls are placed according to map setup before play.", "tags": ["walls", "setup"] }
-                ]
-              },
-              {
-                "title": "Avatars",
-                "rules": [
-                  { "rid": "BP-AVA-001", "text": "Avatars represent their controller’s hero on the board.", "tags": ["avatars"] }
-                ]
-              },
-              {
-                "title": "Summon Pieces",
-                "rules": [
-                  { "rid": "BP-SUM-001", "text": "Summon pieces come in pairs of matching design or color.", "tags": ["summons", "components"] },
-                  { "rid": "BP-SUM-002", "text": "One piece marks the summoned target on the board and the other marks its summoning card, linking them.", "tags": ["summons", "components"] }
-                ]
-              },
-              {
-                "title": "Surface Tiles",
-                "rules": [
-                  { "rid": "BP-SFC-001", "text": "Surface tiles are placed on the board to represent the surface occupying that tile.", "tags": ["surfaces"] }
-                ]
-              },
-              {
-                "title": "Fields",
-                "rules": [
-                  { "rid": "FZ-FIELD-001", "text": "Each player has a field containing their cards and deck.", "tags": ["field"] }
-                ]
-              },
-              {
-                "title": "Action Zone",
-                "rules": [
-                  { "rid": "FZ-ACT-001", "text": "The action zone consists of 5 action slots.", "tags": ["action-zone"] },
-                  { "rid": "FZ-ACT-002", "text": "Each slot may hold one action card.", "tags": ["action-zone"] },
-                  { "rid": "FZ-ACT-003", "text": "The action zone is public knowledge at all times.", "tags": ["action-zone", "public-info"] }
-                ]
-              },
-              {
-                "title": "Deck",
-                "rules": [
-                  { "rid": "FZ-DECK-001", "text": "The deck is where cards are drawn from, especially at the end of each turn.", "tags": ["deck"] },
-                  { "rid": "FZ-DECK-002", "text": "The deck is kept face down and not freely searchable.", "tags": ["deck", "hidden-info"] }
-                ]
-              },
-              {
-                "title": "Purgatory",
-                "rules": [
-                  { "rid": "FZ-PUR-001", "text": "Destroyed, discarded, or attrited cards go to the controller’s Purgatory.", "tags": ["purgatory"] },
-                  { "rid": "FZ-PUR-002", "text": "All purgatories are public knowledge at all times.", "tags": ["purgatory", "public-info"] }
-                ]
-              },
-              {
-                "title": "Abyss",
-                "rules": [
-                  { "rid": "FZ-ABY-001", "text": "Damned or offered cards go to the controller’s Abyss.", "tags": ["abyss"] },
-                  { "rid": "FZ-ABY-002", "text": "All abysses are public knowledge at all times.", "tags": ["abyss", "public-info"] }
-                ]
-              },
-              {
-                "title": "Hero Zone",
-                "rules": [
-                  { "rid": "FZ-HRZ-001", "text": "The Hero zone holds a player's Hero card.", "tags": ["hero-zone"] },
-                  { "rid": "FZ-HRZ-002", "text": "All Hero zones are public knowledge at all times.", "tags": ["hero-zone", "public-info"] }
-                ]
-              },
-              {
-                "title": "The Hand",
-                "rules": [
-                  { "rid": "FZ-HAND-001", "text": "Each player’s hand is private to non‑teammates.", "tags": ["hand", "hidden-info"] }
-                ]
-              }
-            ],
-            "figures": [
-              {
-                "id": "fig-board-labeled",
-                "src": "images/lich/diagrams/board-labeled.png",
-                "caption": "Board with corners, zones, and example walls.",
-                "alt": "Hex board with marked corners and zones"
-              }
-            ],
-            "tags": ["setup", "board", "zones"]
-          },
-          {
-            "id": "initialization",
-            "slug": "initialization",
-            "title": "Initialization",
-            "subsections": [
-              {
-                "title": "Board Setup",
-                "rules": [
-                  { "rid": "INI-SETUP-001", "text": "The board is set up according to the to-be-played map.", "tags": ["setup", "board"] }
-                ]
-              },
-              {
-                "title": "Offering to the Lich",
-                "rules": [
-                  {
-                    "rid": "OFF-001",
-                    "text": "Base Offering: Each player draws 3, chooses 1 to offer (face‑down), then reveal. Highest total source cost goes first; turn order clockwise.",
-                    "tags": ["offering", "turn-order"]
-                  },
-                  {
-                    "rid": "OFF-002",
-                    "text": "Tie breaker: Tied players reshuffle, redraw 3, choose again; reveal and compare.",
-                    "tags": ["offering", "tie-breaker"]
-                  },
-                  {
-                    "rid": "OFF-003",
-                    "text": "Sudden Death: If still tied, tied players reveal cards from top of deck until a winner emerges.",
-                    "tags": ["offering", "sudden-death"]
-                  },
-                  {
-                    "rid": "OFF-004",
-                    "text": "End of Offering: The chosen card is put into its controller’s Abyss; all other cards are shuffled back. Players do not draw initial hands yet.",
-                    "tags": ["offering", "abyss"]
-                  }
-                ]
-              },
-              {
-                "title": "Choosing Starting Positions",
-                "rules": [
-                  { "rid": "STP-001", "text": "In turn order, each player picks an Avatar and places it on a starting corner.", "tags": ["starting-positions"] }
-                ]
-              },
-              {
-                "title": "Initial Hand Draw",
-                "rules": [
-                  { "rid": "DRW-001", "text": "Initial hands are drawn after Avatars are placed.", "tags": ["initial-draw"] }
-                ]
-              },
-              {
-                "title": "Mulligans",
-                "rules": [
-                  { "rid": "MUL-001", "text": "Return your entire hand to your deck, redraw that many cards, then discard 1 card for each mulligan after the first.", "tags": ["mulligan"] }
-                ]
-              },
-              {
-                "title": "End Initialization",
-                "rules": [
-                  { "rid": "INI-END-001", "text": "After all players have drawn their hands and finished Mulligans, the game begins.", "tags": ["start-game"] }
-                ]
-              }
-            ],
-            "tags": ["setup", "offering", "mulligan"]
-          }
-        ]
-      },
-  
-      {
-        "id": "gameplay",
-        "slug": "gameplay",
-        "title": "Gameplay",
-        "pages": [
-          {
-            "id": "turn-phases",
-            "slug": "turn-phases",
-            "title": "Turn Phases",
-            "rules": [
-              { "rid": "PH-START", "text": "Start Phase: Untap all tapped cards and used AP.", "tags": ["start-phase", "untap"] },
-              { "rid": "PH-MAIN",
-                "text": "Main Phase: In any order, multiple times—move up to 2 tiles; play/activate cards/effects as affordable; play 1 Source card. Alternatively, you may offer any number of cards to the Lich (damn them) and immediately go to Status Phase.",
-                "tags": ["main-phase", "movement", "offer"]
-              },
-              { "rid": "PH-STATUS-1", "text": "Status Phase: Resolve statuses; then resolve Death Fog.", "tags": ["status-phase"] },
-              { "rid": "PH-END",
-                "text": "End Phase: Draw up to max hand size; lose 2 health per card above max; place 1 Death Fog tile on the outermost unobstructed ring (not on walls or existing Death Fog). If walls inside a complete layer break, the opening fills with Death Fog.",
-                "tags": ["end-phase", "hand-limit", "death-fog"]
-              }
-            ],
-            "figures": [
-              {
-                "id": "fig-turn-loop",
-                "src": "images/lich/diagrams/turn-loop.png",
-                "caption": "Turn loop and Death Fog expansion.",
-                "alt": "Circular diagram of phases with a ring for Death Fog"
-              }
-            ],
-            "tags": ["phases", "death-fog"]
-          },
-          {
-            "id": "ap-and-combat",
-            "slug": "ap-combat",
-            "title": "Action Points & Combat",
-            "rules": [
-              { "rid": "AP-001", "text": "Each player has 2 AP, refreshed at the Start Phase.", "tags": ["ap"] },
-              { "rid": "AP-002", "text": "Tap effects may be used at reaction speed for 1 AP, or at technique speed during your turn for 1 AP.", "tags": ["ap", "speeds"] },
-              { "rid": "BLK-001", "text": "Blocking: Equipment with ≥1 defense can block damage to an Avatar. If incoming damage ≥ defense, all damage is prevented and the equipment is destroyed. If incoming damage < defense, no damage is dealt. Blocking requires tapping the equipment.", "tags": ["blocking", "equipment"] },
-              { "rid": "DMG-001", "text": "Damage is only 'dealt' when it successfully reduces health of a target.", "tags": ["damage"] },
-              { "rid": "ATK-001", "text": "An attack is any action that hinders movement, reduces health/defense, or applies statuses to a target.", "tags": ["attacks"] }
-            ],
-            "tags": ["ap", "combat", "blocking"]
-          },
-          {
-            "id": "targeting",
-            "slug": "line-of-sight-targeting",
-            "title": "Line of Sight & Targeting",
-            "rules": [
-              { "rid": "LOS-001", "text": "To target with a card, your Avatar must have line of sight (LoS). LoS lines start at the center of the origin tile and extend through faces/vertices.", "tags": ["los"] },
-              { "rid": "LOS-002", "text": "LoS is blocked when a line meets the center of a wall tile or the edge between consecutive wall tiles; Avatars and Summons also block LoS.", "tags": ["los", "walls"] },
-              { "rid": "TGT-001", "text": "Targets can be cards (controller must be in valid LoS), Avatars, Summons, tiles, walls, surfaces, and all field zones.", "tags": ["targets"] }
-            ],
-            "figures": [
-              {
-                "id": "fig-los",
-                "src": "images/lich/diagrams/line-of-sight.png",
-                "caption": "Line-of-sight examples with walls and units.",
-                "alt": "Hex grid with rays showing blocked vs valid LoS"
-              }
-            ],
-            "tags": ["los", "targeting"]
-          }
-        ]
-      },
-
-      {
-        "id": "heroes",
-        "slug": "heroes",
-        "title": "Heroes",
-        "pages": [
-          {
-            "id": "intelligence",
-            "slug": "intelligence",
-            "title": "Intelligence",
-            "rules": [
-              { "rid": "HRO-INT-001", "text": "A Hero's Intelligence is shown by the number in front of the brain symbol on the Hero card.", "tags": ["intelligence"] },
-              { "rid": "HRO-INT-002", "text": "Intelligence equals the player's max hand size.", "tags": ["intelligence", "hand-size"] },
-              { "rid": "HRO-INT-003", "text": "Intelligence is the player's max range for targeting in line of sight.", "tags": ["intelligence", "range"] }
-            ],
-            "tags": ["heroes", "intelligence"]
-          },
-          {
-            "id": "health",
-            "slug": "health",
-            "title": "Health",
-            "rules": [
-              { "rid": "HRO-HP-001", "text": "A Hero’s starting Health is the number in front of the heart symbol on the Hero card.", "tags": ["health"] },
-              { "rid": "HRO-HP-002", "text": "Health decreases when damage is dealt to the Hero's Avatar.", "tags": ["health", "damage"] },
-              { "rid": "HRO-HP-003", "text": "If a Hero’s Health is 0 or less, that player loses and is removed from play.", "tags": ["health", "loss"] }
-            ],
-            "tags": ["heroes", "health"]
-          },
-          {
-            "id": "hero-effect",
-            "slug": "hero-effect",
-            "title": "Hero Effect",
-            "body": [
-              "Heroes may have an accompanying effect which may be played at any time unless otherwise stated. Their effect is described on their Hero card."
-            ],
-            "tags": ["heroes"]
-          },
-          {
-            "id": "death",
-            "slug": "death",
-            "title": "Death",
-            "body": [
-              "If a player dies, all of their cards are removed from play immediately, even if they are in play by other players or elsewhere than their field."
-            ],
-            "tags": ["heroes", "death"]
-          }
-        ]
-      },
-
-      {
-        "id": "card-effects",
-        "slug": "card-effects",
-        "title": "Card Effects",
-        "pages": [
-          {
-            "id": "overview",
-            "slug": "overview",
-            "title": "Overview",
-            "rules": [
-              { "rid": "FX-001", "text": "Card effects can override written rules.", "tags": ["effects"] },
-              { "rid": "FX-002", "text": "Card effects describe additional ways cards can influence the game state.", "tags": ["effects"] },
-              { "rid": "FX-003", "text": "Card effects use keywords to represent pre-defined actions.", "tags": ["effects", "keywords"] }
-            ],
-            "tags": ["effects"]
-          },
-          {
-            "id": "effect-cost",
-            "slug": "effect-cost",
-            "title": "Effect Cost",
-            "rules": [
-              { "rid": "COST-001", "text": "Card effects may have a cost associated with them.", "tags": ["cost"] },
-              { "rid": "COST-002", "text": "The cost is all actions to the left of the effect’s colon (e.g., 'Pay 10 Health : Deal 10 damage to target').", "tags": ["cost"] },
-              { "rid": "COST-003", "text": "The cost of an effect must be paid before the effect is performed.", "tags": ["cost"] }
-            ],
-            "tags": ["effects", "cost"]
-          },
-          {
-            "id": "keywords",
-            "slug": "keywords",
-            "title": "Keywords",
-            "subsections": [
-              {
-                "title": "Tap",
-                "rules": [
-                  { "rid": "KW-TAP-001", "text": "Tap a card.", "tags": ["keyword", "tap"] },
-                  { "rid": "KW-TAP-002", "text": "Cards may either be tapped or untapped.", "tags": ["keyword", "tap"] },
-                  { "rid": "KW-TAP-003", "text": "You may not tap an already tapped card.", "tags": ["keyword", "tap"] },
-                  { "rid": "KW-TAP-004", "text": "Tapped cards untap during their controller’s Start phase.", "tags": ["keyword", "tap"] }
-                ]
-              },
-              {
-                "title": "Untap",
-                "rules": [
-                  { "rid": "KW-UNTAP-001", "text": "Untap a card.", "tags": ["keyword", "untap"] }
-                ]
-              },
-              {
-                "title": "Destroy",
-                "rules": [
-                  { "rid": "KW-DESTROY-001", "text": "Remove an in-play card from the field and send it to its controller’s Purgatory.", "tags": ["keyword", "destroy"] }
-                ]
-              },
-              {
-                "title": "Inflict",
-                "rules": [
-                  { "rid": "KW-INFLICT-001", "text": "Apply a status.", "tags": ["keyword", "inflict"] }
-                ]
-              },
-              {
-                "title": "Deal",
-                "rules": [
-                  { "rid": "KW-DEAL-001", "text": "See section 'Blocking | Dealing Damage'.", "tags": ["keyword", "deal"] }
-                ]
-              },
-              {
-                "title": "Heal",
-                "rules": [
-                  { "rid": "KW-HEAL-001", "text": "Gain an amount of Health.", "tags": ["keyword", "heal"] }
-                ]
-              },
-              {
-                "title": "Place",
-                "rules": [
-                  { "rid": "KW-PLACE-001", "text": "Put a surface on a valid tile.", "tags": ["keyword", "place"] },
-                  { "rid": "KW-PLACE-002", "text": "Invalid tiles include those occupied by walls or Death Fog.", "tags": ["keyword", "place"] }
-                ]
-              },
-              {
-                "title": "Move",
-                "rules": [
-                  { "rid": "KW-MOVE-001", "text": "Change position along adjacent, unoccupied tiles a number of times.", "tags": ["keyword", "move"] },
-                  { "rid": "KW-MOVE-002", "text": "Moving 0 tiles still creates a reactable movement event.", "tags": ["keyword", "move"] }
-                ]
-              },
-              {
-                "title": "Draw",
-                "rules": [
-                  { "rid": "KW-DRAW-001", "text": "Place the top card of your deck into your hand.", "tags": ["keyword", "draw"] }
-                ]
-              },
-              {
-                "title": "Negate",
-                "rules": [
-                  { "rid": "KW-NEGATE-001", "text": "Prevent a reactable game state change.", "tags": ["keyword", "negate"] }
-                ]
-              },
-              {
-                "title": "Attrit",
-                "rules": [
-                  { "rid": "KW-ATTRIT-001", "text": "Take the top card of a player's deck and place it into their Purgatory.", "tags": ["keyword", "attrit"] }
-                ]
-              },
-              {
-                "title": "Discard",
-                "rules": [
-                  { "rid": "KW-DISCARD-001", "text": "Take a card from the controller’s hand and place it into the Purgatory.", "tags": ["keyword", "discard"] }
-                ]
-              },
-              {
-                "title": "Damn",
-                "rules": [
-                  { "rid": "KW-DAMN-001", "text": "Send a card to the controller’s Abyss.", "tags": ["keyword", "damn"] }
-                ]
-              }
-            ],
-            "tags": ["keywords"],
-            "seeAlso": ["statuses", "timing"]
-          }
-        ]
-      },
-
-      {
-        "id": "card-types",
-        "slug": "card-types",
-        "title": "Card Types",
-        "pages": [
-          {
-            "id": "card-source-cost",
-            "slug": "card-source-cost",
-            "title": "Card Source Cost",
-            "body": [
-              "Non-source cards have an associated source cost to play. The source cost is shown by the numbers in front of the colored orbs at the top of a card. Players must have the available source to pay this cost before playing the card."
-            ],
-            "subsections": [
-              {
-                "title": "Source Pool | Available Source",
-                "rules": [
-                  { "rid": "SRC-POOL-001", "text": "When source is granted to a player, it is placed into their source pool.", "tags": ["source-pool"] },
-                  { "rid": "SRC-POOL-002", "text": "A player's source pool empties at the start of each turn.", "tags": ["source-pool"] },
-                  { "rid": "SRC-POOL-003", "text": "All source in the pool is available for card effects and paying source costs.", "tags": ["source-pool"] }
-                ]
-              }
-            ]
-          },
-          {
-            "id": "action-cards",
-            "slug": "action-cards",
-            "title": "Action Cards",
-            "body": [
-              "All action cards occupy one of a player's five action zone slots and are played from hand during the controller's Main phase."
-            ],
-            "subsections": [
-              {
-                "title": "Equipment",
-                "rules": [
-                  { "rid": "EQP-001", "text": "Equipment cards are a type of Action card.", "tags": ["equipment"] },
-                  { "rid": "EQP-002", "text": "Equipment cards have a defense value signified by the shield symbol.", "tags": ["equipment"] },
-                  { "rid": "EQP-003", "text": "The defense value of equipment is used when blocking.", "tags": ["equipment", "blocking"] }
-                ]
-              },
-              {
-                "title": "Summons",
-                "rules": [
-                  { "rid": "SUM-001", "text": "Summon cards are a type of Action card.", "tags": ["summons"] },
-                  { "rid": "SUM-002", "text": "When played, matching summon pieces are placed on the card and the occupied tile.", "tags": ["summons"] },
-                  { "rid": "SUM-003", "text": "The shield value of the card is the Summon's Health.", "tags": ["summons", "health"] },
-                  { "rid": "SUM-004", "text": "If a Summon's Health is 0 or less, remove the Summon and destroy its summoning card, removing both pieces from play.", "tags": ["summons", "destroy"] },
-                  { "rid": "SUM-005", "text": "A Summon's Health regenerates during every player's Start phase.", "tags": ["summons", "health"] }
-                ]
-              },
-              {
-                "title": "Skills",
-                "rules": [
-                  { "rid": "SKL-001", "text": "Skill cards are a type of Action card.", "tags": ["skills"] },
-                  { "rid": "SKL-002", "text": "Skill cards accumulate counters over time.", "tags": ["skills", "counters"] },
-                  { "rid": "SKL-003", "text": "Effects on a Skill card unlock when the required number of counters is reached (e.g., '[3] Tap : Deal 5 Damage to Target').", "tags": ["skills", "effects"] }
-                ]
-              }
-            ]
-          },
-          {
-            "id": "alterations",
-            "slug": "alterations",
-            "title": "Alterations",
-            "rules": [
-              { "rid": "ALT-001", "text": "Alterations are neither Action cards nor Tactic cards.", "tags": ["alterations"] },
-              { "rid": "ALT-002", "text": "Alterations modify other cards.", "tags": ["alterations"] },
-              { "rid": "ALT-003", "text": "An altered card is modified based on the alteration's effect.", "tags": ["alterations"] }
-            ]
-          },
-          {
-            "id": "tactic-cards",
-            "slug": "tactic-cards",
-            "title": "Tactic Cards",
-            "subsections": [
-              {
-                "title": "Techniques",
-                "rules": [
-                  { "rid": "TEC-001", "text": "Techniques are a type of Tactic card.", "tags": ["techniques"] },
-                  { "rid": "TEC-002", "text": "Techniques may be played from hand during the player's Main phase.", "tags": ["techniques"] }
-                ]
-              },
-              {
-                "title": "Reactions",
-                "rules": [
-                  { "rid": "REA-001", "text": "Reactions are a type of Tactic card.", "tags": ["reactions"] },
-                  { "rid": "REA-002", "text": "Reactions may be played after a reactable event within line of sight.", "tags": ["reactions"] },
-                  { "rid": "REA-003", "text": "Not reactable events include: source played or tapped, Death Fog placed, statuses resolved, phase changes, drawing cards, targets destroyed, and offering to the Lich.", "tags": ["reactions"] }
-                ]
-              }
-            ]
-          },
-          {
-            "id": "source-cards",
-            "slug": "source-cards",
-            "title": "Source Cards",
-            "subsections": [
-              {
-                "title": "Pure Sources",
-                "rules": [
-                  { "rid": "SRC-PR-001", "text": "Pure Sources tap for only one source of one type.", "tags": ["pure-source"] }
-                ]
-              },
-              {
-                "title": "Non-Pure Sources",
-                "rules": [
-                  { "rid": "SRC-NP-001", "text": "Non-Pure Sources tap for more than one of a type or include additional effects.", "tags": ["non-pure-source"] }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-
-      {
-        "id": "timing",
-        "slug": "timing-card-speeds-stack",
-        "title": "Timing, Card Speeds & The Stack",
-        "pages": [
-          {
-            "id": "overview",
-            "slug": "overview",
-            "title": "Overview",
-            "body": [
-              "Once cards or effects are played or activated, their effects resolve on a 'first in, last out' stack order."
-            ],
-            "rules": [
-              { "rid": "STK-001", "text": "The Stack resolves effects in first-in, last-out order.", "tags": ["stack"] }
-            ]
-          },
-          {
-            "id": "fizzling",
-            "slug": "fizzling",
-            "title": "Fizzling",
-            "body": [
-              "A card 'fizzles' when its effect cannot fully resolve; the cost is still paid but no part of the fizzled effect resolves."
-            ],
-            "rules": [
-              { "rid": "FIZ-001", "text": "Fizzled effects do not resolve, but their costs remain paid.", "tags": ["fizzle"] }
-            ]
-          },
-          {
-            "id": "technique-speed",
-            "slug": "technique-speed",
-            "title": "Technique Speed",
-            "rules": [
-              { "rid": "SPD-TEC-001", "text": "Technique cards are played at technique speed by default.", "tags": ["technique-speed"] },
-              { "rid": "SPD-TEC-002", "text": "Cards played at technique speed cannot add to an existing stack and always create their own stack.", "tags": ["technique-speed"] }
-            ]
-          },
-          {
-            "id": "reaction-speed",
-            "slug": "reaction-speed",
-            "title": "Reaction Speed",
-            "rules": [
-              { "rid": "SPD-REA-001", "text": "All effects and cards are played at reaction speed by default unless otherwise specified.", "tags": ["reaction-speed"] },
-              { "rid": "SPD-REA-002", "text": "Cards played at reaction speed may add to existing stacks or create their own independent stacks.", "tags": ["reaction-speed"] }
-            ]
-          },
-          {
-            "id": "examples",
-            "slug": "examples",
-            "title": "Examples",
-            "rules": [
-              { "rid": "EXM-001", "text": "Example: Player one taps equipment to deal 5 damage; Player two responds with 'negate an incoming attack'. Player two's effect resolves first, negating the attack and causing the first effect to fizzle.", "tags": ["examples"] }
-            ]
-          }
-        ]
-      },
-
-      {
-        "id": "modifiers",
-        "slug": "modifiers",
-        "title": "Modifiers",
-        "pages": [
-          {
-            "id": "overview",
-            "slug": "overview",
-            "title": "Overview",
-            "body": [
-              "Modifiers are keywords that alter the card abilities."
-            ]
-          }
-        ]
-      },
-
-      {
-        "id": "statuses",
-        "slug": "statuses",
-        "title": "Statuses",
-        "pages": [
-          {
-            "id": "overview",
-            "slug": "overview",
-            "title": "Overview",
-            "body": [
-              "Statuses are inflicted onto targets, changing their behavior. Inflicted statuses are signified by status counters placed onto the afflicted targets."
-            ]
-          },
-          {
-            "id": "status-definitions",
-            "slug": "status-definitions",
-            "title": "Status Definitions",
-            "subsections": [
-              { "title": "Penetrate", "rules": [ { "rid": "ST-PEN-001", "text": "Line of sight does not stop at Avatars or Summons.", "tags": ["status", "los"] }, { "rid": "ST-PEN-002", "text": "Multiple targets along the same line of sight may be targeted.", "tags": ["status", "los"] } ] },
-              { "title": "Reprise", "rules": [ { "rid": "ST-REP-001", "text": "Allows a card's Tap effect to resolve multiple separate consecutive times for a single AP.", "tags": ["status", "ap"] } ] },
-              { "title": "Overwhelm", "rules": [ { "rid": "ST-OVR-001", "text": "If incoming damage is blocked, any damage above the amount blocked is still dealt.", "tags": ["status", "damage"] } ] },
-              { "title": "Invisible", "rules": [ { "rid": "ST-INV-001", "text": "Invisible targets may only be targeted from adjacent tiles.", "tags": ["status", "targeting"] } ] },
-              { "title": "Blind", "rules": [ { "rid": "ST-BLD-001", "text": "A blind target may only target adjacent targets.", "tags": ["status", "targeting"] } ] },
-              { "title": "Burning", "rules": [ { "rid": "ST-BRN-001", "text": "A burning target is dealt 5 damage during its status phase.", "tags": ["status", "damage-over-time"] } ] },
-              { "title": "Ensnared", "rules": [ { "rid": "ST-ENS-001", "text": "You may not move.", "tags": ["status", "movement"] } ] },
-              { "title": "Wet", "rules": [ { "rid": "ST-WET-001", "text": "If inflicted with Burning, remove an equal number of Wet and Burning counters.", "tags": ["status", "interaction"] }, { "rid": "ST-WET-002", "text": "If inflicted with Sepsis, remove an equal number of Wet and Sepsis counters.", "tags": ["status", "interaction"] } ] },
-              { "title": "Sepsis", "rules": [ { "rid": "ST-SEP-001", "text": "You must spend 1 AP per tile moved.", "tags": ["status", "movement", "ap"] } ] },
-              { "title": "Lich’s Curse", "rules": [ { "rid": "ST-LCUR-001", "text": "On Death Fog during Status Phase, your health becomes zero and you may not heal.", "tags": ["status", "death-fog"] }, { "rid": "ST-LCUR-002", "text": "This loss of health is not damage and the status is non-removable via card effects.", "tags": ["status", "non-removable"] } ] },
-              { "title": "Impending Doom", "rules": [ { "rid": "ST-IMP-001", "text": "On Death Fog during Status Phase, lose half your remaining health, rounded up.", "tags": ["status", "death-fog"] }, { "rid": "ST-IMP-002", "text": "At the end of your status phase, remove Impending Doom and inflict Lich’s Curse.", "tags": ["status", "death-fog"] }, { "rid": "ST-IMP-003", "text": "You may not heal; this loss is not damage and is non-removable via card effects.", "tags": ["status", "non-removable"] } ] },
-              { "title": "Stunned", "rules": [ { "rid": "ST-STU-001", "text": "A stunned target may not play cards or activate abilities at reaction speed, including reactions.", "tags": ["status", "speeds"] }, { "rid": "ST-STU-002", "text": "A stunned target may activate abilities at technique speed.", "tags": ["status", "speeds"] }, { "rid": "ST-STU-003", "text": "A stunned target cannot block.", "tags": ["status", "blocking"] }, { "rid": "ST-STU-004", "text": "Tap abilities are now at technique speed.", "tags": ["status", "speeds"] } ] },
-              { "title": "Possessed", "rules": [ { "rid": "ST-POS-001", "text": "The inflicting player controls all movement of a possessed Avatar or Summon.", "tags": ["status", "control"] }, { "rid": "ST-POS-002", "text": "Possessed status is tracked with paired possession counters placed on the possessor and the possessed.", "tags": ["status", "control"] } ] }
-            ]
-          }
-        ]
-      },
-
-      {
-        "id": "surfaces",
-        "slug": "surfaces",
-        "title": "Surfaces",
-        "pages": [
-          {
-            "id": "overview",
-            "slug": "overview",
-            "title": "Overview",
-            "body": [
-              "Surfaces occupy tiles, adding effects to the tile. If a surface is placed on an already surfaced tile, the preceding surface is removed unless otherwise stated. Surfaces apply their status the moment a target is within the surface."
-            ]
-          },
-          {
-            "id": "surface-definitions",
-            "slug": "surface-definitions",
-            "title": "Surface Definitions",
-            "subsections": [
-              { "title": "Death Fog", "rules": [ { "rid": "SF-DF-001", "text": "Surfaces may not be placed on Death Fog.", "tags": ["surface"] }, { "rid": "SF-DF-002", "text": "Death Fog overrides all other surfaces when placed.", "tags": ["surface"] }, { "rid": "SF-DF-003", "text": "Inflicts Impending Doom to occupying targets.", "tags": ["surface", "status"] }, { "rid": "SF-DF-004", "text": "Death Fog may not be removed or destroyed once placed.", "tags": ["surface", "non-removable"] } ] },
-              { "title": "Fire", "rules": [ { "rid": "SF-FIR-001", "text": "Inflicts Burning 1 to occupying targets during the status phase.", "tags": ["surface", "burning"] }, { "rid": "SF-FIR-002", "text": "When placed on Water, Steam is placed instead.", "tags": ["surface"] } ] },
-              { "title": "Sludge", "rules": [ { "rid": "SF-SLG-001", "text": "Inflicts Sepsis 2 to occupying target during the status phase.", "tags": ["surface", "sepsis"] } ] },
-              { "title": "Vines", "rules": [ { "rid": "SF-VIN-001", "text": "Blocks line of sight.", "tags": ["surface", "los"] }, { "rid": "SF-VIN-002", "text": "Inflicts Ensnared to occupying targets.", "tags": ["surface", "status"] }, { "rid": "SF-VIN-003", "text": "If adjacent to a fire surface at the start of a status phase, convert to a fire surface.", "tags": ["surface"] }, { "rid": "SF-VIN-004", "text": "Vines have 1 HP and are destroyed when reduced to 0.", "tags": ["surface", "destructible"] } ] },
-              { "title": "Water", "rules": [ { "rid": "SF-WAT-001", "text": "When placed on Fire, Steam is placed instead.", "tags": ["surface"] }, { "rid": "SF-WAT-002", "text": "Inflicts Wet to occupying targets.", "tags": ["surface", "status"] } ] },
-              { "title": "Steam", "rules": [ { "rid": "SF-STM-001", "text": "Steam does nothing.", "tags": ["surface"] } ] },
-              { "title": "Smoke", "rules": [ { "rid": "SF-SMK-001", "text": "Smoke blocks line of sight to preceding tiles.", "tags": ["surface", "los"] }, { "rid": "SF-SMK-002", "text": "Smoke does not block line of sight to its own tile.", "tags": ["surface", "los"] }, { "rid": "SF-SMK-003", "text": "Smoke inflicts blindness 1 to occupying targets.", "tags": ["surface", "blind"] } ] }
-            ]
-          }
-        ]
-      }
-    ],
-  
-    "keywords": [
-      { "id": "KW-TAP", "name": "Tap", "definition": "Change a card to tapped; you cannot tap an already tapped card; tapped cards untap during their controller’s Start Phase.", "tags": ["keyword"] },
-      { "id": "KW-UNTAP", "name": "Untap", "definition": "Change a card to untapped.", "tags": ["keyword"] },
-      { "id": "KW-DESTROY", "name": "Destroy", "definition": "Remove an in‑play card and send it to its controller’s Purgatory.", "tags": ["keyword"] },
-      { "id": "KW-INFLICT", "name": "Inflict", "definition": "Apply a status.", "tags": ["keyword"] },
-      { "id": "KW-DEAL", "name": "Deal", "definition": "See Blocking/Dealing Damage rules for how damage is considered 'dealt'.", "tags": ["keyword"] },
-      { "id": "KW-HEAL", "name": "Heal", "definition": "Gain an amount of Health.", "tags": ["keyword"] },
-      { "id": "KW-PLACE", "name": "Place", "definition": "Put a surface on a valid tile (not walls, not Death Fog).", "tags": ["keyword"] },
-      { "id": "KW-MOVE", "name": "Move", "definition": "Change position along adjacent unoccupied tiles up to the stated amount; moving 0 still creates a reactable movement event.", "tags": ["keyword"] },
-      { "id": "KW-DRAW", "name": "Draw", "definition": "Move the top card of your deck into your hand.", "tags": ["keyword"] },
-      { "id": "KW-NEGATE", "name": "Negate", "definition": "Prevent a reactable game state change.", "tags": ["keyword"] },
-      { "id": "KW-ATTRIT", "name": "Attrit", "definition": "Put the top card of a player’s deck into their Purgatory.", "tags": ["keyword"] },
-      { "id": "KW-DISCARD", "name": "Discard", "definition": "Put a card from hand into Purgatory.", "tags": ["keyword"] },
-      { "id": "KW-DAMN", "name": "Damn", "definition": "Send a card to its controller’s Abyss.", "tags": ["keyword"] }
-    ],
-  
-    "statuses": [
-      { "id": "ST-PENETRATE", "name": "Penetrate", "effects": ["LoS does not stop at Avatars or Summons; multiple targets along one LoS line may be targeted."], "tags": ["status", "los"] },
-      { "id": "ST-REPRISE", "name": "Reprise", "effects": ["Allows a card’s Tap effect (if any) to resolve multiple separate consecutive times for a single AP."], "tags": ["status", "ap"] },
-      { "id": "ST-OVERWHELM", "name": "Overwhelm", "effects": ["If blocked, excess damage beyond the block is still dealt to the original target."], "tags": ["status", "damage"] },
-      { "id": "ST-INVISIBLE", "name": "Invisible", "effects": ["May only be targeted from adjacent tiles."], "tags": ["status", "targeting"] },
-      { "id": "ST-BLIND", "name": "Blind", "effects": ["May only target adjacent targets."], "tags": ["status", "targeting"] },
-      { "id": "ST-BURNING", "name": "Burning", "effects": ["During Status Phase, take 5 damage."], "tags": ["status", "damage-over-time"] },
-      { "id": "ST-ENSNARED", "name": "Ensnared", "effects": ["You may not move."], "tags": ["status", "movement"] },
-      { "id": "ST-WET", "name": "Wet", "effects": ["If inflicted with Burning, remove an equal number of Wet and Burning counters; if inflicted with Sepsis, remove an equal number of Wet and Sepsis counters."], "tags": ["status", "interaction"] },
-      { "id": "ST-SEPSIS", "name": "Sepsis", "effects": ["You must spend 1 AP per tile moved."], "tags": ["status", "movement", "ap"] },
-      { "id": "ST-LICHS-CURSE", "name": "Lich’s Curse", "effects": ["If on a Death Fog tile during Status Phase, health becomes 0; you may not heal; this loss is not 'damage'; cannot be removed by card effects."], "tags": ["status", "death-fog", "non-removable"] },
-      { "id": "ST-IMPENDING-DOOM", "name": "Impending Doom", "effects": ["If on Death Fog during Status Phase: lose half your remaining health (rounded up); then remove Impending Doom and inflict Lich’s Curse; you may not heal; this loss is not 'damage'; non‑removable by effects."], "tags": ["status", "death-fog", "non-removable"] },
-      { "id": "ST-STUNNED", "name": "Stunned", "effects": ["May not play/activate at reaction speed; may use technique-speed; cannot block; Tap abilities are now technique-speed."], "tags": ["status", "speeds"] },
-      { "id": "ST-POSSESSED", "name": "Possessed", "effects": ["Inflictor controls movement of the possessed Avatar or Summon; tracked via paired possession counters on the possessor/possessed."], "tags": ["status", "control"] }
-    ],
-  
-    "surfaces": [
-      {
-        "id": "SF-DEATH-FOG",
-        "name": "Death Fog",
-        "properties": ["Cannot place other surfaces on Death Fog; overrides all other surfaces; inflicts Impending Doom to occupants; cannot be removed/destroyed once placed."],
-        "inflicts": ["ST-IMPENDING-DOOM"],
-        "tags": ["surface", "non-removable"]
-      },
-      { "id": "SF-FIRE", "name": "Fire", "properties": ["When placed on Water, becomes Steam."], "inflicts": ["ST-BURNING"], "tags": ["surface"] },
-      { "id": "SF-SLUDGE", "name": "Sludge", "properties": [], "inflicts": ["ST-SEPSIS"], "intensity": 2, "tags": ["surface"] },
-      {
-        "id": "SF-VINES",
-        "name": "Vines",
-        "properties": ["Blocks LoS", "Inflicts Ensnared", "If adjacent to Fire at the start of a Status Phase, converts to Fire", "Has 1 HP and can be destroyed at 0"],
-        "inflicts": ["ST-ENSNARED"],
-        "tags": ["surface", "destructible"]
-      },
-      { "id": "SF-WATER", "name": "Water", "properties": ["When placed on Fire, becomes Steam."], "inflicts": ["ST-WET"], "tags": ["surface"] },
-      { "id": "SF-STEAM", "name": "Steam", "properties": ["No additional effect."], "inflicts": [], "tags": ["surface"] },
-      {
-        "id": "SF-SMOKE",
-        "name": "Smoke",
-        "properties": ["Blocks LoS to preceding tiles but not to its own tile."],
-        "inflicts": ["ST-BLIND"],
-        "intensity": 1,
-        "tags": ["surface"]
-      }
-    ],
-  
-    "crossrefs": [
-      { "from": "PH-END", "to": "SF-DEATH-FOG", "why": "End Phase places Death Fog" },
-      { "from": "LOS-001", "to": "SF-SMOKE", "why": "Smoke blocks LoS" },
-      { "from": "KW-PLACE", "to": "SF-DEATH-FOG", "why": "Cannot place onto Death Fog" },
-      { "from": "ST-IMPENDING-DOOM", "to": "ST-LICHS-CURSE", "why": "Automatic conversion after Status Phase" },
-      { "from": "EQP-001", "to": "BLK-001", "why": "Equipment used for blocking" }
-    ]
-  }
-  
+    {
+      "id": "gameplay",
+      "slug": "gameplay",
+      "title": "Gameplay",
+      "pages": [
+        {
+          "id": "turn-phases",
+          "slug": "turn-phases",
+          "title": "Turn Phases",
+          "rules": [
+            {
+              "rid": "PH-START",
+              "text": "Start Phase: Untap all tapped cards and used AP.",
+              "tags": [
+                "start-phase",
+                "untap"
+              ]
+            },
+            {
+              "rid": "PH-MAIN",
+              "text": "Main Phase: In any order, multiple times—move up to 2 tiles; play/activate cards/effects as affordable; play 1 Source card. Alternatively, you may offer any number of cards to the Lich (damn them) and immediately go to Status Phase.",
+              "tags": [
+                "main-phase",
+                "movement",
+                "offer"
+              ]
+            },
+            {
+              "rid": "PH-STATUS-1",
+              "text": "Status Phase: Resolve statuses; then resolve Death Fog.",
+              "tags": [
+                "status-phase"
+              ]
+            },
+            {
+              "rid": "PH-END",
+              "text": "End Phase: Draw up to max hand size; lose 2 health per card above max; place 1 Death Fog tile on the outermost unobstructed ring (not on walls or existing Death Fog). If walls inside a complete layer break, the opening fills with Death Fog.",
+              "tags": [
+                "end-phase",
+                "hand-limit",
+                "death-fog"
+              ]
+            }
+          ],
+          "figures": [
+            {
+              "id": "fig-turn-loop",
+              "src": "images/lich/diagrams/turn-loop.png",
+              "caption": "Turn loop and Death Fog expansion.",
+              "alt": "Circular diagram of phases with a ring for Death Fog"
+            }
+          ],
+          "tags": [
+            "phases",
+            "death-fog"
+          ]
+        },
+        {
+          "id": "ap-and-combat",
+          "slug": "ap-combat",
+          "title": "Action Points & Combat",
+          "rules": [
+            {
+              "rid": "AP-001",
+              "text": "Each player has 2 AP, refreshed at the Start Phase.",
+              "tags": [
+                "ap"
+              ]
+            },
+            {
+              "rid": "AP-002",
+              "text": "Tap effects may be used at reaction speed for 1 AP, or at technique speed during your turn for 1 AP.",
+              "tags": [
+                "ap",
+                "speeds"
+              ]
+            },
+            {
+              "rid": "BLK-001",
+              "text": "Blocking: Equipment with ≥1 defense can block damage to an Avatar. If incoming damage ≥ defense, all damage is prevented and the equipment is destroyed. If incoming damage < defense, no damage is dealt. Blocking requires tapping the equipment.",
+              "tags": [
+                "blocking",
+                "equipment"
+              ]
+            },
+            {
+              "rid": "DMG-001",
+              "text": "Damage is only 'dealt' when it successfully reduces health of a target.",
+              "tags": [
+                "damage"
+              ]
+            },
+            {
+              "rid": "ATK-001",
+              "text": "An attack is any action that hinders movement, reduces health/defense, or applies statuses to a target.",
+              "tags": [
+                "attacks"
+              ]
+            }
+          ],
+          "tags": [
+            "ap",
+            "combat",
+            "blocking"
+          ]
+        },
+        {
+          "id": "targeting",
+          "slug": "line-of-sight-targeting",
+          "title": "Line of Sight & Targeting",
+          "rules": [
+            {
+              "rid": "LOS-001",
+              "text": "To target with a card, your Avatar must have line of sight (LoS). LoS lines start at the center of the origin tile and extend through faces/vertices.",
+              "tags": [
+                "los"
+              ]
+            },
+            {
+              "rid": "LOS-002",
+              "text": "LoS is blocked when a line meets the center of a wall tile or the edge between consecutive wall tiles; Avatars and Summons also block LoS.",
+              "tags": [
+                "los",
+                "walls"
+              ]
+            },
+            {
+              "rid": "TGT-001",
+              "text": "Targets can be cards (controller must be in valid LoS), Avatars, Summons, tiles, walls, surfaces, and all field zones.",
+              "tags": [
+                "targets"
+              ]
+            }
+          ],
+          "figures": [
+            {
+              "id": "fig-los",
+              "src": "images/lich/diagrams/line-of-sight.png",
+              "caption": "Line-of-sight examples with walls and units.",
+              "alt": "Hex grid with rays showing blocked vs valid LoS"
+            }
+          ],
+          "tags": [
+            "los",
+            "targeting"
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
+    },
+    {
+      "id": "heroes",
+      "slug": "heroes",
+      "title": "Heroes",
+      "pages": [
+        {
+          "id": "intelligence",
+          "slug": "intelligence",
+          "title": "Intelligence",
+          "rules": [
+            {
+              "rid": "HRO-INT-001",
+              "text": "A Hero's Intelligence is shown by the number in front of the brain symbol on the Hero card.",
+              "tags": [
+                "intelligence"
+              ]
+            },
+            {
+              "rid": "HRO-INT-002",
+              "text": "Intelligence equals the player's max hand size.",
+              "tags": [
+                "intelligence",
+                "hand-size"
+              ]
+            },
+            {
+              "rid": "HRO-INT-003",
+              "text": "Intelligence is the player's max range for targeting in line of sight.",
+              "tags": [
+                "intelligence",
+                "range"
+              ]
+            }
+          ],
+          "tags": [
+            "heroes",
+            "intelligence"
+          ]
+        },
+        {
+          "id": "health",
+          "slug": "health",
+          "title": "Health",
+          "rules": [
+            {
+              "rid": "HRO-HP-001",
+              "text": "A Hero’s starting Health is the number in front of the heart symbol on the Hero card.",
+              "tags": [
+                "health"
+              ]
+            },
+            {
+              "rid": "HRO-HP-002",
+              "text": "Health decreases when damage is dealt to the Hero's Avatar.",
+              "tags": [
+                "health",
+                "damage"
+              ]
+            },
+            {
+              "rid": "HRO-HP-003",
+              "text": "If a Hero’s Health is 0 or less, that player loses and is removed from play.",
+              "tags": [
+                "health",
+                "loss"
+              ]
+            }
+          ],
+          "tags": [
+            "heroes",
+            "health"
+          ]
+        },
+        {
+          "id": "hero-effect",
+          "slug": "hero-effect",
+          "title": "Hero Effect",
+          "body": [
+            "Heroes may have an accompanying effect which may be played at any time unless otherwise stated. Their effect is described on their Hero card."
+          ],
+          "tags": [
+            "heroes"
+          ]
+        },
+        {
+          "id": "death",
+          "slug": "death",
+          "title": "Death",
+          "body": [
+            "If a player dies, all of their cards are removed from play immediately, even if they are in play by other players or elsewhere than their field."
+          ],
+          "tags": [
+            "heroes",
+            "death"
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
+    },
+    {
+      "id": "card-effects",
+      "slug": "card-effects",
+      "title": "Card Effects",
+      "pages": [
+        {
+          "id": "overview",
+          "slug": "overview",
+          "title": "Overview",
+          "rules": [
+            {
+              "rid": "FX-001",
+              "text": "Card effects can override written rules.",
+              "tags": [
+                "effects"
+              ]
+            },
+            {
+              "rid": "FX-002",
+              "text": "Card effects describe additional ways cards can influence the game state.",
+              "tags": [
+                "effects"
+              ]
+            },
+            {
+              "rid": "FX-003",
+              "text": "Card effects use keywords to represent pre-defined actions.",
+              "tags": [
+                "effects",
+                "keywords"
+              ]
+            }
+          ],
+          "tags": [
+            "effects"
+          ]
+        },
+        {
+          "id": "effect-cost",
+          "slug": "effect-cost",
+          "title": "Effect Cost",
+          "rules": [
+            {
+              "rid": "COST-001",
+              "text": "Card effects may have a cost associated with them.",
+              "tags": [
+                "cost"
+              ]
+            },
+            {
+              "rid": "COST-002",
+              "text": "The cost is all actions to the left of the effect’s colon (e.g., 'Pay 10 Health : Deal 10 damage to target').",
+              "tags": [
+                "cost"
+              ]
+            },
+            {
+              "rid": "COST-003",
+              "text": "The cost of an effect must be paid before the effect is performed.",
+              "tags": [
+                "cost"
+              ]
+            }
+          ],
+          "tags": [
+            "effects",
+            "cost"
+          ]
+        },
+        {
+          "id": "keywords",
+          "slug": "keywords",
+          "title": "Keywords",
+          "subsections": [
+            {
+              "title": "Tap",
+              "rules": [
+                {
+                  "rid": "KW-TAP-001",
+                  "text": "Tap a card.",
+                  "tags": [
+                    "keyword",
+                    "tap"
+                  ]
+                },
+                {
+                  "rid": "KW-TAP-002",
+                  "text": "Cards may either be tapped or untapped.",
+                  "tags": [
+                    "keyword",
+                    "tap"
+                  ]
+                },
+                {
+                  "rid": "KW-TAP-003",
+                  "text": "You may not tap an already tapped card.",
+                  "tags": [
+                    "keyword",
+                    "tap"
+                  ]
+                },
+                {
+                  "rid": "KW-TAP-004",
+                  "text": "Tapped cards untap during their controller’s Start phase.",
+                  "tags": [
+                    "keyword",
+                    "tap"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Untap",
+              "rules": [
+                {
+                  "rid": "KW-UNTAP-001",
+                  "text": "Untap a card.",
+                  "tags": [
+                    "keyword",
+                    "untap"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Destroy",
+              "rules": [
+                {
+                  "rid": "KW-DESTROY-001",
+                  "text": "Remove an in-play card from the field and send it to its controller’s Purgatory.",
+                  "tags": [
+                    "keyword",
+                    "destroy"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Inflict",
+              "rules": [
+                {
+                  "rid": "KW-INFLICT-001",
+                  "text": "Apply a status.",
+                  "tags": [
+                    "keyword",
+                    "inflict"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Deal",
+              "rules": [
+                {
+                  "rid": "KW-DEAL-001",
+                  "text": "See section 'Blocking | Dealing Damage'.",
+                  "tags": [
+                    "keyword",
+                    "deal"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Heal",
+              "rules": [
+                {
+                  "rid": "KW-HEAL-001",
+                  "text": "Gain an amount of Health.",
+                  "tags": [
+                    "keyword",
+                    "heal"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Place",
+              "rules": [
+                {
+                  "rid": "KW-PLACE-001",
+                  "text": "Put a surface on a valid tile.",
+                  "tags": [
+                    "keyword",
+                    "place"
+                  ]
+                },
+                {
+                  "rid": "KW-PLACE-002",
+                  "text": "Invalid tiles include those occupied by walls or Death Fog.",
+                  "tags": [
+                    "keyword",
+                    "place"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Move",
+              "rules": [
+                {
+                  "rid": "KW-MOVE-001",
+                  "text": "Change position along adjacent, unoccupied tiles a number of times.",
+                  "tags": [
+                    "keyword",
+                    "move"
+                  ]
+                },
+                {
+                  "rid": "KW-MOVE-002",
+                  "text": "Moving 0 tiles still creates a reactable movement event.",
+                  "tags": [
+                    "keyword",
+                    "move"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Draw",
+              "rules": [
+                {
+                  "rid": "KW-DRAW-001",
+                  "text": "Place the top card of your deck into your hand.",
+                  "tags": [
+                    "keyword",
+                    "draw"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Negate",
+              "rules": [
+                {
+                  "rid": "KW-NEGATE-001",
+                  "text": "Prevent a reactable game state change.",
+                  "tags": [
+                    "keyword",
+                    "negate"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Attrit",
+              "rules": [
+                {
+                  "rid": "KW-ATTRIT-001",
+                  "text": "Take the top card of a player's deck and place it into their Purgatory.",
+                  "tags": [
+                    "keyword",
+                    "attrit"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Discard",
+              "rules": [
+                {
+                  "rid": "KW-DISCARD-001",
+                  "text": "Take a card from the controller’s hand and place it into the Purgatory.",
+                  "tags": [
+                    "keyword",
+                    "discard"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Damn",
+              "rules": [
+                {
+                  "rid": "KW-DAMN-001",
+                  "text": "Send a card to the controller’s Abyss.",
+                  "tags": [
+                    "keyword",
+                    "damn"
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags": [
+            "keywords"
+          ],
+          "seeAlso": [
+            "statuses",
+            "timing"
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
+    },
+    {
+      "id": "card-types",
+      "slug": "card-types",
+      "title": "Card Types",
+      "pages": [
+        {
+          "id": "card-source-cost",
+          "slug": "card-source-cost",
+          "title": "Card Source Cost",
+          "body": [
+            "Non-source cards have an associated source cost to play. The source cost is shown by the numbers in front of the colored orbs at the top of a card. Players must have the available source to pay this cost before playing the card."
+          ],
+          "subsections": [
+            {
+              "title": "Source Pool | Available Source",
+              "rules": [
+                {
+                  "rid": "SRC-POOL-001",
+                  "text": "When source is granted to a player, it is placed into their source pool.",
+                  "tags": [
+                    "source-pool"
+                  ]
+                },
+                {
+                  "rid": "SRC-POOL-002",
+                  "text": "A player's source pool empties at the start of each turn.",
+                  "tags": [
+                    "source-pool"
+                  ]
+                },
+                {
+                  "rid": "SRC-POOL-003",
+                  "text": "All source in the pool is available for card effects and paying source costs.",
+                  "tags": [
+                    "source-pool"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "action-cards",
+          "slug": "action-cards",
+          "title": "Action Cards",
+          "body": [
+            "All action cards occupy one of a player's five action zone slots and are played from hand during the controller's Main phase."
+          ],
+          "subsections": [
+            {
+              "title": "Equipment",
+              "rules": [
+                {
+                  "rid": "EQP-001",
+                  "text": "Equipment cards are a type of Action card.",
+                  "tags": [
+                    "equipment"
+                  ]
+                },
+                {
+                  "rid": "EQP-002",
+                  "text": "Equipment cards have a defense value signified by the shield symbol.",
+                  "tags": [
+                    "equipment"
+                  ]
+                },
+                {
+                  "rid": "EQP-003",
+                  "text": "The defense value of equipment is used when blocking.",
+                  "tags": [
+                    "equipment",
+                    "blocking"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Summons",
+              "rules": [
+                {
+                  "rid": "SUM-001",
+                  "text": "Summon cards are a type of Action card.",
+                  "tags": [
+                    "summons"
+                  ]
+                },
+                {
+                  "rid": "SUM-002",
+                  "text": "When played, matching summon pieces are placed on the card and the occupied tile.",
+                  "tags": [
+                    "summons"
+                  ]
+                },
+                {
+                  "rid": "SUM-003",
+                  "text": "The shield value of the card is the Summon's Health.",
+                  "tags": [
+                    "summons",
+                    "health"
+                  ]
+                },
+                {
+                  "rid": "SUM-004",
+                  "text": "If a Summon's Health is 0 or less, remove the Summon and destroy its summoning card, removing both pieces from play.",
+                  "tags": [
+                    "summons",
+                    "destroy"
+                  ]
+                },
+                {
+                  "rid": "SUM-005",
+                  "text": "A Summon's Health regenerates during every player's Start phase.",
+                  "tags": [
+                    "summons",
+                    "health"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Skills",
+              "rules": [
+                {
+                  "rid": "SKL-001",
+                  "text": "Skill cards are a type of Action card.",
+                  "tags": [
+                    "skills"
+                  ]
+                },
+                {
+                  "rid": "SKL-002",
+                  "text": "Skill cards accumulate counters over time.",
+                  "tags": [
+                    "skills",
+                    "counters"
+                  ]
+                },
+                {
+                  "rid": "SKL-003",
+                  "text": "Effects on a Skill card unlock when the required number of counters is reached (e.g., '[3] Tap : Deal 5 Damage to Target').",
+                  "tags": [
+                    "skills",
+                    "effects"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "alterations",
+          "slug": "alterations",
+          "title": "Alterations",
+          "rules": [
+            {
+              "rid": "ALT-001",
+              "text": "Alterations are neither Action cards nor Tactic cards.",
+              "tags": [
+                "alterations"
+              ]
+            },
+            {
+              "rid": "ALT-002",
+              "text": "Alterations modify other cards.",
+              "tags": [
+                "alterations"
+              ]
+            },
+            {
+              "rid": "ALT-003",
+              "text": "An altered card is modified based on the alteration's effect.",
+              "tags": [
+                "alterations"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "tactic-cards",
+          "slug": "tactic-cards",
+          "title": "Tactic Cards",
+          "subsections": [
+            {
+              "title": "Techniques",
+              "rules": [
+                {
+                  "rid": "TEC-001",
+                  "text": "Techniques are a type of Tactic card.",
+                  "tags": [
+                    "techniques"
+                  ]
+                },
+                {
+                  "rid": "TEC-002",
+                  "text": "Techniques may be played from hand during the player's Main phase.",
+                  "tags": [
+                    "techniques"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Reactions",
+              "rules": [
+                {
+                  "rid": "REA-001",
+                  "text": "Reactions are a type of Tactic card.",
+                  "tags": [
+                    "reactions"
+                  ]
+                },
+                {
+                  "rid": "REA-002",
+                  "text": "Reactions may be played after a reactable event within line of sight.",
+                  "tags": [
+                    "reactions"
+                  ]
+                },
+                {
+                  "rid": "REA-003",
+                  "text": "Not reactable events include: source played or tapped, Death Fog placed, statuses resolved, phase changes, drawing cards, targets destroyed, and offering to the Lich.",
+                  "tags": [
+                    "reactions"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "source-cards",
+          "slug": "source-cards",
+          "title": "Source Cards",
+          "subsections": [
+            {
+              "title": "Pure Sources",
+              "rules": [
+                {
+                  "rid": "SRC-PR-001",
+                  "text": "Pure Sources tap for only one source of one type.",
+                  "tags": [
+                    "pure-source"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Non-Pure Sources",
+              "rules": [
+                {
+                  "rid": "SRC-NP-001",
+                  "text": "Non-Pure Sources tap for more than one of a type or include additional effects.",
+                  "tags": [
+                    "non-pure-source"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
+    },
+    {
+      "id": "timing",
+      "slug": "timing-card-speeds-stack",
+      "title": "Timing, Card Speeds & The Stack",
+      "pages": [
+        {
+          "id": "overview",
+          "slug": "overview",
+          "title": "Overview",
+          "body": [
+            "Once cards or effects are played or activated, their effects resolve on a 'first in, last out' stack order."
+          ],
+          "rules": [
+            {
+              "rid": "STK-001",
+              "text": "The Stack resolves effects in first-in, last-out order.",
+              "tags": [
+                "stack"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "fizzling",
+          "slug": "fizzling",
+          "title": "Fizzling",
+          "body": [
+            "A card 'fizzles' when its effect cannot fully resolve; the cost is still paid but no part of the fizzled effect resolves."
+          ],
+          "rules": [
+            {
+              "rid": "FIZ-001",
+              "text": "Fizzled effects do not resolve, but their costs remain paid.",
+              "tags": [
+                "fizzle"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "technique-speed",
+          "slug": "technique-speed",
+          "title": "Technique Speed",
+          "rules": [
+            {
+              "rid": "SPD-TEC-001",
+              "text": "Technique cards are played at technique speed by default.",
+              "tags": [
+                "technique-speed"
+              ]
+            },
+            {
+              "rid": "SPD-TEC-002",
+              "text": "Cards played at technique speed cannot add to an existing stack and always create their own stack.",
+              "tags": [
+                "technique-speed"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "reaction-speed",
+          "slug": "reaction-speed",
+          "title": "Reaction Speed",
+          "rules": [
+            {
+              "rid": "SPD-REA-001",
+              "text": "All effects and cards are played at reaction speed by default unless otherwise specified.",
+              "tags": [
+                "reaction-speed"
+              ]
+            },
+            {
+              "rid": "SPD-REA-002",
+              "text": "Cards played at reaction speed may add to existing stacks or create their own independent stacks.",
+              "tags": [
+                "reaction-speed"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "examples",
+          "slug": "examples",
+          "title": "Examples",
+          "rules": [
+            {
+              "rid": "EXM-001",
+              "text": "Example: Player one taps equipment to deal 5 damage; Player two responds with 'negate an incoming attack'. Player two's effect resolves first, negating the attack and causing the first effect to fizzle.",
+              "tags": [
+                "examples"
+              ]
+            }
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
+    },
+    {
+      "id": "modifiers",
+      "slug": "modifiers",
+      "title": "Modifiers",
+      "pages": [
+        {
+          "id": "overview",
+          "slug": "overview",
+          "title": "Overview",
+          "body": [
+            "Modifiers are keywords that alter the card abilities."
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
+    },
+    {
+      "id": "statuses",
+      "slug": "statuses",
+      "title": "Statuses",
+      "pages": [
+        {
+          "id": "overview",
+          "slug": "overview",
+          "title": "Overview",
+          "body": [
+            "Statuses are inflicted onto targets, changing their behavior. Inflicted statuses are signified by status counters placed onto the afflicted targets."
+          ]
+        },
+        {
+          "id": "status-definitions",
+          "slug": "status-definitions",
+          "title": "Status Definitions",
+          "subsections": [
+            {
+              "title": "Penetrate",
+              "rules": [
+                {
+                  "rid": "ST-PEN-001",
+                  "text": "Line of sight does not stop at Avatars or Summons.",
+                  "tags": [
+                    "status",
+                    "los"
+                  ]
+                },
+                {
+                  "rid": "ST-PEN-002",
+                  "text": "Multiple targets along the same line of sight may be targeted.",
+                  "tags": [
+                    "status",
+                    "los"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Reprise",
+              "rules": [
+                {
+                  "rid": "ST-REP-001",
+                  "text": "Allows a card's Tap effect to resolve multiple separate consecutive times for a single AP.",
+                  "tags": [
+                    "status",
+                    "ap"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Overwhelm",
+              "rules": [
+                {
+                  "rid": "ST-OVR-001",
+                  "text": "If incoming damage is blocked, any damage above the amount blocked is still dealt.",
+                  "tags": [
+                    "status",
+                    "damage"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Invisible",
+              "rules": [
+                {
+                  "rid": "ST-INV-001",
+                  "text": "Invisible targets may only be targeted from adjacent tiles.",
+                  "tags": [
+                    "status",
+                    "targeting"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Blind",
+              "rules": [
+                {
+                  "rid": "ST-BLD-001",
+                  "text": "A blind target may only target adjacent targets.",
+                  "tags": [
+                    "status",
+                    "targeting"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Burning",
+              "rules": [
+                {
+                  "rid": "ST-BRN-001",
+                  "text": "A burning target is dealt 5 damage during its status phase.",
+                  "tags": [
+                    "status",
+                    "damage-over-time"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Ensnared",
+              "rules": [
+                {
+                  "rid": "ST-ENS-001",
+                  "text": "You may not move.",
+                  "tags": [
+                    "status",
+                    "movement"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Wet",
+              "rules": [
+                {
+                  "rid": "ST-WET-001",
+                  "text": "If inflicted with Burning, remove an equal number of Wet and Burning counters.",
+                  "tags": [
+                    "status",
+                    "interaction"
+                  ]
+                },
+                {
+                  "rid": "ST-WET-002",
+                  "text": "If inflicted with Sepsis, remove an equal number of Wet and Sepsis counters.",
+                  "tags": [
+                    "status",
+                    "interaction"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Sepsis",
+              "rules": [
+                {
+                  "rid": "ST-SEP-001",
+                  "text": "You must spend 1 AP per tile moved.",
+                  "tags": [
+                    "status",
+                    "movement",
+                    "ap"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Lich’s Curse",
+              "rules": [
+                {
+                  "rid": "ST-LCUR-001",
+                  "text": "On Death Fog during Status Phase, your health becomes zero and you may not heal.",
+                  "tags": [
+                    "status",
+                    "death-fog"
+                  ]
+                },
+                {
+                  "rid": "ST-LCUR-002",
+                  "text": "This loss of health is not damage and the status is non-removable via card effects.",
+                  "tags": [
+                    "status",
+                    "non-removable"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Impending Doom",
+              "rules": [
+                {
+                  "rid": "ST-IMP-001",
+                  "text": "On Death Fog during Status Phase, lose half your remaining health, rounded up.",
+                  "tags": [
+                    "status",
+                    "death-fog"
+                  ]
+                },
+                {
+                  "rid": "ST-IMP-002",
+                  "text": "At the end of your status phase, remove Impending Doom and inflict Lich’s Curse.",
+                  "tags": [
+                    "status",
+                    "death-fog"
+                  ]
+                },
+                {
+                  "rid": "ST-IMP-003",
+                  "text": "You may not heal; this loss is not damage and is non-removable via card effects.",
+                  "tags": [
+                    "status",
+                    "non-removable"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Stunned",
+              "rules": [
+                {
+                  "rid": "ST-STU-001",
+                  "text": "A stunned target may not play cards or activate abilities at reaction speed, including reactions.",
+                  "tags": [
+                    "status",
+                    "speeds"
+                  ]
+                },
+                {
+                  "rid": "ST-STU-002",
+                  "text": "A stunned target may activate abilities at technique speed.",
+                  "tags": [
+                    "status",
+                    "speeds"
+                  ]
+                },
+                {
+                  "rid": "ST-STU-003",
+                  "text": "A stunned target cannot block.",
+                  "tags": [
+                    "status",
+                    "blocking"
+                  ]
+                },
+                {
+                  "rid": "ST-STU-004",
+                  "text": "Tap abilities are now at technique speed.",
+                  "tags": [
+                    "status",
+                    "speeds"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Possessed",
+              "rules": [
+                {
+                  "rid": "ST-POS-001",
+                  "text": "The inflicting player controls all movement of a possessed Avatar or Summon.",
+                  "tags": [
+                    "status",
+                    "control"
+                  ]
+                },
+                {
+                  "rid": "ST-POS-002",
+                  "text": "Possessed status is tracked with paired possession counters placed on the possessor and the possessed.",
+                  "tags": [
+                    "status",
+                    "control"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
+    },
+    {
+      "id": "surfaces",
+      "slug": "surfaces",
+      "title": "Surfaces",
+      "pages": [
+        {
+          "id": "overview",
+          "slug": "overview",
+          "title": "Overview",
+          "body": [
+            "Surfaces occupy tiles, adding effects to the tile. If a surface is placed on an already surfaced tile, the preceding surface is removed unless otherwise stated. Surfaces apply their status the moment a target is within the surface."
+          ]
+        },
+        {
+          "id": "surface-definitions",
+          "slug": "surface-definitions",
+          "title": "Surface Definitions",
+          "subsections": [
+            {
+              "title": "Death Fog",
+              "rules": [
+                {
+                  "rid": "SF-DF-001",
+                  "text": "Surfaces may not be placed on Death Fog.",
+                  "tags": [
+                    "surface"
+                  ]
+                },
+                {
+                  "rid": "SF-DF-002",
+                  "text": "Death Fog overrides all other surfaces when placed.",
+                  "tags": [
+                    "surface"
+                  ]
+                },
+                {
+                  "rid": "SF-DF-003",
+                  "text": "Inflicts Impending Doom to occupying targets.",
+                  "tags": [
+                    "surface",
+                    "status"
+                  ]
+                },
+                {
+                  "rid": "SF-DF-004",
+                  "text": "Death Fog may not be removed or destroyed once placed.",
+                  "tags": [
+                    "surface",
+                    "non-removable"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Fire",
+              "rules": [
+                {
+                  "rid": "SF-FIR-001",
+                  "text": "Inflicts Burning 1 to occupying targets during the status phase.",
+                  "tags": [
+                    "surface",
+                    "burning"
+                  ]
+                },
+                {
+                  "rid": "SF-FIR-002",
+                  "text": "When placed on Water, Steam is placed instead.",
+                  "tags": [
+                    "surface"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Sludge",
+              "rules": [
+                {
+                  "rid": "SF-SLG-001",
+                  "text": "Inflicts Sepsis 2 to occupying target during the status phase.",
+                  "tags": [
+                    "surface",
+                    "sepsis"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Vines",
+              "rules": [
+                {
+                  "rid": "SF-VIN-001",
+                  "text": "Blocks line of sight.",
+                  "tags": [
+                    "surface",
+                    "los"
+                  ]
+                },
+                {
+                  "rid": "SF-VIN-002",
+                  "text": "Inflicts Ensnared to occupying targets.",
+                  "tags": [
+                    "surface",
+                    "status"
+                  ]
+                },
+                {
+                  "rid": "SF-VIN-003",
+                  "text": "If adjacent to a fire surface at the start of a status phase, convert to a fire surface.",
+                  "tags": [
+                    "surface"
+                  ]
+                },
+                {
+                  "rid": "SF-VIN-004",
+                  "text": "Vines have 1 HP and are destroyed when reduced to 0.",
+                  "tags": [
+                    "surface",
+                    "destructible"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Water",
+              "rules": [
+                {
+                  "rid": "SF-WAT-001",
+                  "text": "When placed on Fire, Steam is placed instead.",
+                  "tags": [
+                    "surface"
+                  ]
+                },
+                {
+                  "rid": "SF-WAT-002",
+                  "text": "Inflicts Wet to occupying targets.",
+                  "tags": [
+                    "surface",
+                    "status"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Steam",
+              "rules": [
+                {
+                  "rid": "SF-STM-001",
+                  "text": "Steam does nothing.",
+                  "tags": [
+                    "surface"
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Smoke",
+              "rules": [
+                {
+                  "rid": "SF-SMK-001",
+                  "text": "Smoke blocks line of sight to preceding tiles.",
+                  "tags": [
+                    "surface",
+                    "los"
+                  ]
+                },
+                {
+                  "rid": "SF-SMK-002",
+                  "text": "Smoke does not block line of sight to its own tile.",
+                  "tags": [
+                    "surface",
+                    "los"
+                  ]
+                },
+                {
+                  "rid": "SF-SMK-003",
+                  "text": "Smoke inflicts blindness 1 to occupying targets.",
+                  "tags": [
+                    "surface",
+                    "blind"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "icon": "https://imageslot.com/v1/64x64"
+    }
+  ],
+  "keywords": [
+    {
+      "id": "KW-TAP",
+      "name": "Tap",
+      "definition": "Change a card to tapped; you cannot tap an already tapped card; tapped cards untap during their controller’s Start Phase.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-UNTAP",
+      "name": "Untap",
+      "definition": "Change a card to untapped.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-DESTROY",
+      "name": "Destroy",
+      "definition": "Remove an in‑play card and send it to its controller’s Purgatory.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-INFLICT",
+      "name": "Inflict",
+      "definition": "Apply a status.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-DEAL",
+      "name": "Deal",
+      "definition": "See Blocking/Dealing Damage rules for how damage is considered 'dealt'.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-HEAL",
+      "name": "Heal",
+      "definition": "Gain an amount of Health.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-PLACE",
+      "name": "Place",
+      "definition": "Put a surface on a valid tile (not walls, not Death Fog).",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-MOVE",
+      "name": "Move",
+      "definition": "Change position along adjacent unoccupied tiles up to the stated amount; moving 0 still creates a reactable movement event.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-DRAW",
+      "name": "Draw",
+      "definition": "Move the top card of your deck into your hand.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-NEGATE",
+      "name": "Negate",
+      "definition": "Prevent a reactable game state change.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-ATTRIT",
+      "name": "Attrit",
+      "definition": "Put the top card of a player’s deck into their Purgatory.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-DISCARD",
+      "name": "Discard",
+      "definition": "Put a card from hand into Purgatory.",
+      "tags": [
+        "keyword"
+      ]
+    },
+    {
+      "id": "KW-DAMN",
+      "name": "Damn",
+      "definition": "Send a card to its controller’s Abyss.",
+      "tags": [
+        "keyword"
+      ]
+    }
+  ],
+  "statuses": [
+    {
+      "id": "ST-PENETRATE",
+      "name": "Penetrate",
+      "effects": [
+        "LoS does not stop at Avatars or Summons; multiple targets along one LoS line may be targeted."
+      ],
+      "tags": [
+        "status",
+        "los"
+      ]
+    },
+    {
+      "id": "ST-REPRISE",
+      "name": "Reprise",
+      "effects": [
+        "Allows a card’s Tap effect (if any) to resolve multiple separate consecutive times for a single AP."
+      ],
+      "tags": [
+        "status",
+        "ap"
+      ]
+    },
+    {
+      "id": "ST-OVERWHELM",
+      "name": "Overwhelm",
+      "effects": [
+        "If blocked, excess damage beyond the block is still dealt to the original target."
+      ],
+      "tags": [
+        "status",
+        "damage"
+      ]
+    },
+    {
+      "id": "ST-INVISIBLE",
+      "name": "Invisible",
+      "effects": [
+        "May only be targeted from adjacent tiles."
+      ],
+      "tags": [
+        "status",
+        "targeting"
+      ]
+    },
+    {
+      "id": "ST-BLIND",
+      "name": "Blind",
+      "effects": [
+        "May only target adjacent targets."
+      ],
+      "tags": [
+        "status",
+        "targeting"
+      ]
+    },
+    {
+      "id": "ST-BURNING",
+      "name": "Burning",
+      "effects": [
+        "During Status Phase, take 5 damage."
+      ],
+      "tags": [
+        "status",
+        "damage-over-time"
+      ]
+    },
+    {
+      "id": "ST-ENSNARED",
+      "name": "Ensnared",
+      "effects": [
+        "You may not move."
+      ],
+      "tags": [
+        "status",
+        "movement"
+      ]
+    },
+    {
+      "id": "ST-WET",
+      "name": "Wet",
+      "effects": [
+        "If inflicted with Burning, remove an equal number of Wet and Burning counters; if inflicted with Sepsis, remove an equal number of Wet and Sepsis counters."
+      ],
+      "tags": [
+        "status",
+        "interaction"
+      ]
+    },
+    {
+      "id": "ST-SEPSIS",
+      "name": "Sepsis",
+      "effects": [
+        "You must spend 1 AP per tile moved."
+      ],
+      "tags": [
+        "status",
+        "movement",
+        "ap"
+      ]
+    },
+    {
+      "id": "ST-LICHS-CURSE",
+      "name": "Lich’s Curse",
+      "effects": [
+        "If on a Death Fog tile during Status Phase, health becomes 0; you may not heal; this loss is not 'damage'; cannot be removed by card effects."
+      ],
+      "tags": [
+        "status",
+        "death-fog",
+        "non-removable"
+      ]
+    },
+    {
+      "id": "ST-IMPENDING-DOOM",
+      "name": "Impending Doom",
+      "effects": [
+        "If on Death Fog during Status Phase: lose half your remaining health (rounded up); then remove Impending Doom and inflict Lich’s Curse; you may not heal; this loss is not 'damage'; non‑removable by effects."
+      ],
+      "tags": [
+        "status",
+        "death-fog",
+        "non-removable"
+      ]
+    },
+    {
+      "id": "ST-STUNNED",
+      "name": "Stunned",
+      "effects": [
+        "May not play/activate at reaction speed; may use technique-speed; cannot block; Tap abilities are now technique-speed."
+      ],
+      "tags": [
+        "status",
+        "speeds"
+      ]
+    },
+    {
+      "id": "ST-POSSESSED",
+      "name": "Possessed",
+      "effects": [
+        "Inflictor controls movement of the possessed Avatar or Summon; tracked via paired possession counters on the possessor/possessed."
+      ],
+      "tags": [
+        "status",
+        "control"
+      ]
+    }
+  ],
+  "surfaces": [
+    {
+      "id": "SF-DEATH-FOG",
+      "name": "Death Fog",
+      "properties": [
+        "Cannot place other surfaces on Death Fog; overrides all other surfaces; inflicts Impending Doom to occupants; cannot be removed/destroyed once placed."
+      ],
+      "inflicts": [
+        "ST-IMPENDING-DOOM"
+      ],
+      "tags": [
+        "surface",
+        "non-removable"
+      ]
+    },
+    {
+      "id": "SF-FIRE",
+      "name": "Fire",
+      "properties": [
+        "When placed on Water, becomes Steam."
+      ],
+      "inflicts": [
+        "ST-BURNING"
+      ],
+      "tags": [
+        "surface"
+      ]
+    },
+    {
+      "id": "SF-SLUDGE",
+      "name": "Sludge",
+      "properties": [],
+      "inflicts": [
+        "ST-SEPSIS"
+      ],
+      "intensity": 2,
+      "tags": [
+        "surface"
+      ]
+    },
+    {
+      "id": "SF-VINES",
+      "name": "Vines",
+      "properties": [
+        "Blocks LoS",
+        "Inflicts Ensnared",
+        "If adjacent to Fire at the start of a Status Phase, converts to Fire",
+        "Has 1 HP and can be destroyed at 0"
+      ],
+      "inflicts": [
+        "ST-ENSNARED"
+      ],
+      "tags": [
+        "surface",
+        "destructible"
+      ]
+    },
+    {
+      "id": "SF-WATER",
+      "name": "Water",
+      "properties": [
+        "When placed on Fire, becomes Steam."
+      ],
+      "inflicts": [
+        "ST-WET"
+      ],
+      "tags": [
+        "surface"
+      ]
+    },
+    {
+      "id": "SF-STEAM",
+      "name": "Steam",
+      "properties": [
+        "No additional effect."
+      ],
+      "inflicts": [],
+      "tags": [
+        "surface"
+      ]
+    },
+    {
+      "id": "SF-SMOKE",
+      "name": "Smoke",
+      "properties": [
+        "Blocks LoS to preceding tiles but not to its own tile."
+      ],
+      "inflicts": [
+        "ST-BLIND"
+      ],
+      "intensity": 1,
+      "tags": [
+        "surface"
+      ]
+    }
+  ],
+  "crossrefs": [
+    {
+      "from": "PH-END",
+      "to": "SF-DEATH-FOG",
+      "why": "End Phase places Death Fog"
+    },
+    {
+      "from": "LOS-001",
+      "to": "SF-SMOKE",
+      "why": "Smoke blocks LoS"
+    },
+    {
+      "from": "KW-PLACE",
+      "to": "SF-DEATH-FOG",
+      "why": "Cannot place onto Death Fog"
+    },
+    {
+      "from": "ST-IMPENDING-DOOM",
+      "to": "ST-LICHS-CURSE",
+      "why": "Automatic conversion after Status Phase"
+    },
+    {
+      "from": "EQP-001",
+      "to": "BLK-001",
+      "why": "Equipment used for blocking"
+    }
+  ]
+}

--- a/html/assets/js/lich-rulebook.js
+++ b/html/assets/js/lich-rulebook.js
@@ -27,6 +27,15 @@ document.addEventListener('DOMContentLoaded', () => {
             if (section.title) {
                 const h2 = document.createElement('h2');
                 h2.textContent = section.title;
+
+                if (section.icon) {
+                    const icon = document.createElement('img');
+                    icon.src = section.icon;
+                    icon.alt = '';
+                    icon.classList.add('section-icon');
+                    h2.prepend(icon);
+                }
+
                 sectionEl.appendChild(h2);
             }
 


### PR DESCRIPTION
## Summary
- add placeholder icon URLs to all rulebook sections
- render section icons before headings
- style section icons for sizing and alignment

## Testing
- `node - <<'NODE' ...` (renders sections and counts 10 icons)
- ⚠️ `npm install jsdom` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_b_689bb9a7ecdc8333b0217b8410495519