### PR TITLE
feat: support rulebook page banners

### DIFF
--- a/html/assets/css/lich-rulebook.css
+++ b/html/assets/css/lich-rulebook.css
@@ -117,3 +117,10 @@
     vertical-align: middle;
 }
 
+/* Page banner images */
+#rulebook-container .page-banner {
+    width: 100%;
+    display: block;
+    margin: 0 0 1rem;
+}
+

--- a/html/assets/data/lich-rulebook.json
+++ b/html/assets/data/lich-rulebook.json
@@ -22,6 +22,7 @@
           "id": "welcome",
           "slug": "welcome",
           "title": "Welcome to the L.I.C.H. Rulebook",
+          "banner": "https://imageslot.com/v1/1000x200",
           "body": [
             "L.I.C.H. is a tactical board & card game played on a hex grid with heroes (Avatars), summons, surfaces, and source-driven cards.",
             "<p><strong>Readability tip:</strong> Each numbered rule is linkable; hover the link icon to copy a direct URL.</p>"
@@ -1257,6 +1258,7 @@
           "id": "overview",
           "slug": "overview",
           "title": "Overview",
+          "banner": "https://imageslot.com/v1/1000x200",
           "body": [
             "Once cards or effects are played or activated, their effects resolve on a 'first in, last out' stack order."
           ],

--- a/html/assets/js/lich-rulebook.js
+++ b/html/assets/js/lich-rulebook.js
@@ -48,6 +48,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 h3.innerHTML = `<a id="${pageId}" href="#${pageId}">${page.title}</a>`;
                 pageEl.appendChild(h3);
 
+                if (page.banner) {
+                    const banner = document.createElement('img');
+                    banner.classList.add('page-banner');
+                    banner.src = page.banner;
+                    banner.alt = '';
+                    pageEl.appendChild(banner);
+                }
+
                 const tagSet = new Set(page.tags || []);
 
                 if (page.body) {


### PR DESCRIPTION
## Summary
- support optional banner images for rulebook pages
- render banner images in rulebook section pages
- style rulebook banner images

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_b_689bbde2e91083338fbbf0f314b85a40