### PR TITLE
feat: support icons and diagrams in rulebook rules

### DIFF
--- a/html/assets/css/lich-rulebook.css
+++ b/html/assets/css/lich-rulebook.css
@@ -124,3 +124,17 @@
     margin: 0 0 1rem;
 }
 
+/* Rule-level images */
+#rulebook-container .rule-icon {
+    width: 24px;
+    height: 24px;
+    margin: 0 0.5rem 0 0;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+#rulebook-container .rule-diagram {
+    display: block;
+    margin: 0.5rem auto 0;
+}
+

--- a/html/assets/data/lich-rulebook.json
+++ b/html/assets/data/lich-rulebook.json
@@ -56,6 +56,7 @@
             {
               "rid": "BRD-001",
               "text": "The game uses a hexagonal board with a hex grid; each side has 6 hexes.",
+              "icon": "https://imageslot.com/v1/24x24",
               "tags": [
                 "board",
                 "dimensions"
@@ -64,9 +65,20 @@
             {
               "rid": "BRD-002",
               "text": "Starting positions are the six corners of the board.",
+              "diagram": "https://imageslot.com/v1/400x200",
               "tags": [
                 "board",
                 "starting-positions"
+              ]
+            },
+            {
+              "rid": "BRD-003",
+              "text": "Placeholder rule showcasing both icon and diagram.",
+              "icon": "https://imageslot.com/v1/24x24",
+              "diagram": "https://imageslot.com/v1/400x200",
+              "tags": [
+                "board",
+                "placeholder"
               ]
             }
           ],

--- a/html/assets/js/lich-rulebook.js
+++ b/html/assets/js/lich-rulebook.js
@@ -71,6 +71,23 @@ document.addEventListener('DOMContentLoaded', () => {
                     page.rules.forEach((rule) => {
                         const li = document.createElement('li');
                         li.innerHTML = `<strong>${rule.rid}</strong> ${rule.text}`;
+
+                        if (rule.icon) {
+                            const icon = document.createElement('img');
+                            icon.src = rule.icon;
+                            icon.alt = '';
+                            icon.classList.add('rule-icon');
+                            li.prepend(icon);
+                        }
+
+                        if (rule.diagram) {
+                            const diagram = document.createElement('img');
+                            diagram.src = rule.diagram;
+                            diagram.alt = '';
+                            diagram.classList.add('rule-diagram');
+                            li.appendChild(diagram);
+                        }
+
                         list.appendChild(li);
                         (rule.tags || []).forEach((t) => tagSet.add(t));
                     });
@@ -87,6 +104,23 @@ document.addEventListener('DOMContentLoaded', () => {
                         sub.rules.forEach((rule) => {
                             const li = document.createElement('li');
                             li.innerHTML = `<strong>${rule.rid}</strong> ${rule.text}`;
+
+                            if (rule.icon) {
+                                const icon = document.createElement('img');
+                                icon.src = rule.icon;
+                                icon.alt = '';
+                                icon.classList.add('rule-icon');
+                                li.prepend(icon);
+                            }
+
+                            if (rule.diagram) {
+                                const diagram = document.createElement('img');
+                                diagram.src = rule.diagram;
+                                diagram.alt = '';
+                                diagram.classList.add('rule-diagram');
+                                li.appendChild(diagram);
+                            }
+
                             subList.appendChild(li);
                             (rule.tags || []).forEach((t) => tagSet.add(t));
                         });


### PR DESCRIPTION
## Summary
- allow rule entries to include optional icon or diagram URLs
- render rule icons/diagrams in rulebook and style them
- add placeholder rules demonstrating icons and diagrams

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('html/assets/data/lich-rulebook.json','utf8')); console.log('JSON valid');"`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bc2221afc8333be2ab2d8c5b26634