### PR TITLE
feat: reward first-time Discord link

### DIFF
--- a/html/Kickback/Backend/Config/ServiceCredentials.php
+++ b/html/Kickback/Backend/Config/ServiceCredentials.php
@@ -342,6 +342,20 @@ final class ServiceCredentials implements \ArrayAccess
         return is_string($val) ? $val : null;
     }
 
+    /** @return null|string */
+    public static function get_discord_link_channel_id() : ?string
+    {
+        $val = self::get('discord_link_channel_id');
+        return is_string($val) ? $val : null;
+    }
+
+    /** @return null|string */
+    public static function get_discord_link_reward_item_id() : ?string
+    {
+        $val = self::get('discord_link_reward_item_id');
+        return is_string($val) ? $val : null;
+    }
+
     public static function instance() : ServiceCredentials
     {
         if ( !isset(self::$instance) )

--- a/meta/config-examples/credentials.ini
+++ b/meta/config-examples/credentials.ini
@@ -48,6 +48,8 @@ discord_redirect_uri        = "https://example.com/discord/callback"
 discord_guild_id            = "*****"
 discord_bot_token           = "*****"
 discord_verified_role_id    = "*****"
+discord_link_channel_id     = "*****"
+discord_link_reward_item_id = "*****"
 
 ; Kickback Kingdom auth info; used to establish sessions with backend API
 kk_service_key     = "*****"


### PR DESCRIPTION
## Summary
- announce first-time Discord links
- grant loot and channel announcement on link
- add credentials for link channel and reward item

## Testing
- `composer install`
- `./vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`
- `php -l html/Kickback/Backend/Config/ServiceCredentials.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3bd2819188333bc7b0a8f6ebf7d58