### PR TITLE
Add Discord link flavor text and use in account page

### DIFF
--- a/html/Kickback/Backend/Controllers/FlavorTextController.php
+++ b/html/Kickback/Backend/Controllers/FlavorTextController.php
@@ -29,6 +29,21 @@ class FlavorTextController
         return "🎉 Exciting Announcement! 🎉 The $raffleName has come to a thrilling conclusion. Congratulations to $winnerUsername, the lucky winner! We thank everyone who participated and encourage you to stay tuned for more exciting events and opportunities in the future.";
     }
 
+    public static function getDiscordLinkFlavorText(string $username) : string
+    {
+        $flavorTexts = [
+            "$username has forged their Discord connection—let the realms resound with celebration!",
+            "Hear ye, hear ye! $username has bound their Discord spirit to the kingdom's chorus!",
+            "Trumpets sound! $username's Discord link now echoes through the halls of Kickback Kingdom.",
+            "By royal decree, $username's voice now rings across Discord, united with our realm!",
+            "From distant servers they arrive—$username has linked Discord and joins the festivity!",
+            "$username's Discord sigil now glows alongside the banners of Kickback Kingdom!",
+        ];
+
+        $randomIndex = array_rand($flavorTexts);
+        return $flavorTexts[$randomIndex];
+    }
+
     public static function getNewcomerIntroduction(string $username) : string
     {
         $introductions = [

--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -534,7 +534,7 @@ class SocialMediaController
         if ($firstLink) {
             $channelId = ServiceCredentials::get_discord_link_channel_id();
             if ($channelId) {
-                self::sendChannelMessage($channelId, $account->username . ' just linked their Discord account!');
+                self::sendChannelMessage($channelId, FlavorTextController::getDiscordLinkFlavorText($account->username));
             }
             $rewardItemId = ServiceCredentials::get_discord_link_reward_item_id();
             if ($rewardItemId) {

--- a/html/account-settings.php
+++ b/html/account-settings.php
@@ -5,6 +5,7 @@ $session = require(\Kickback\SCRIPT_ROOT . "/api/v1/engine/session/verifySession
 require("php-components/base-page-pull-active-account-info.php");
 
 use Kickback\Services\Session;
+use Kickback\Backend\Controllers\FlavorTextController;
 
 if (!Session::isLoggedIn()) {
     header("Location: login.php?redirect=" . urlencode("account-settings.php"));
@@ -118,6 +119,9 @@ $account = Session::getCurrentAccount();
                                         <i class="fa-solid fa-link-slash"></i>
                                         <span>Unlink</span>
                                     </button>
+                                </div>
+                                <div class="mt-2 small text-muted">
+                                    <?= htmlspecialchars(FlavorTextController::getDiscordLinkFlavorText($account->username)); ?>
                                 </div>
                             <?php } ?>
                         </div>


### PR DESCRIPTION
## Summary
- add FlavorTextController::getDiscordLinkFlavorText for celebratory messages
- announce Discord linking with themed messages in SocialMediaController
- display Discord link flavor text on account settings page when linked

## Testing
- `php -l html/Kickback/Backend/Controllers/FlavorTextController.php`
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`
- `php -l html/account-settings.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3c3108d688333972e9a892e6a46af