### PR TITLE
Add Steam account columns

### DIFF
--- a/html/Kickback/Backend/Models/Account.php
+++ b/html/Kickback/Backend/Models/Account.php
@@ -13,5 +13,7 @@ class Account extends RecordId
     public ForeignRecordId $passageId;
     public ?string $discordUserId = null;
     public ?string $discordUsername = null;
+    public ?string $steamUserId = null;
+    public ?string $steamUsername = null;
 }
 ?>

--- a/html/Kickback/Backend/Views/vAccount.php
+++ b/html/Kickback/Backend/Views/vAccount.php
@@ -27,6 +27,9 @@ class vAccount extends vRecordId
     public ?string $discordUserId = null;
     public ?string $discordUsername = null;
 
+    public ?string $steamUserId = null;
+    public ?string $steamUsername = null;
+
     public string $title;
 
     public bool $isAdmin;
@@ -100,7 +103,7 @@ class vAccount extends vRecordId
 
     public function isSteamLinked() : bool
     {
-        return false;
+        return !is_null($this->steamUserId);
     }
 
     public function hasThirdPartyLinks() : bool

--- a/meta/schema/kickback-kingdom-schema.mysql
+++ b/meta/schema/kickback-kingdom-schema.mysql
@@ -86,10 +86,13 @@ CREATE TABLE `account` (
   `passage_id` int(11) DEFAULT NULL,
   `DiscordUserId` varchar(32) COLLATE utf8mb4_bin DEFAULT NULL,
   `DiscordUsername` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
+  `SteamUserId` varchar(32) COLLATE utf8mb4_bin DEFAULT NULL,
+  `SteamUsername` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
   PRIMARY KEY (`Id`),
   UNIQUE KEY `Email` (`Email`),
   UNIQUE KEY `unique_passage_id` (`passage_id`),
-  UNIQUE KEY `unique_discord_user_id` (`DiscordUserId`)
+  UNIQUE KEY `unique_discord_user_id` (`DiscordUserId`),
+  UNIQUE KEY `unique_steam_user_id` (`SteamUserId`)
 ) ENGINE=InnoDB AUTO_INCREMENT=52 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/meta/schema/migrations/20240601_add_steam_columns.sql
+++ b/meta/schema/migrations/20240601_add_steam_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `account`
+  ADD COLUMN `SteamUserId` varchar(32) COLLATE utf8mb4_bin DEFAULT NULL,
+  ADD COLUMN `SteamUsername` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
+  ADD UNIQUE KEY `unique_steam_user_id` (`SteamUserId`);
+


### PR DESCRIPTION
## Summary
- allow storing Steam user IDs and usernames in accounts
- expose Steam linking on account views
- add database migration and schema updates for Steam fields

## Testing
- `php -l html/Kickback/Backend/Models/Account.php`
- `php -l html/Kickback/Backend/Views/vAccount.php`
- `./meta/phpstan.sh` *(fails: Could not open input file: ./meta/../html/vendor/composer/phpstan/phpstan/phpstan)*
- `composer install` *(fails: Required package "openai-php/client" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_b_68a3dc16b93483338aeabe3fda27c70a