### PR TITLE
Add Steam credentials support

### DIFF
--- a/html/Kickback/Backend/Config/ServiceCredentials.php
+++ b/html/Kickback/Backend/Config/ServiceCredentials.php
@@ -183,6 +183,14 @@ final class ServiceCredentials implements \ArrayAccess
         $error_count += (int)!$this->credential_string_exists       ("discord_bot_token");
         $error_count += (int)!$this->credential_string_exists       ("discord_verified_role_id");
 
+        // Steam OAuth info; used for login.
+        $error_count += (int)!$this->credential_string_exists       ("steam_oauth_client_id");
+        $error_count += (int)!$this->credential_string_exists       ("steam_oauth_client_secret");
+        $error_count += (int)!$this->credential_of_given_type_exists("steam_redirect_uri", "URL", FILTER_VALIDATE_URL);
+        if (array_key_exists('steam_web_api_key', $this->entries)) {
+            $error_count += (int)!$this->credential_string_exists   ("steam_web_api_key");
+        }
+
         // Kickback Kingdom auth info; used to establish sessions with backend API
         $error_count += (int)!$this->credential_string_exists       ("kk_service_key");
 
@@ -346,6 +354,34 @@ final class ServiceCredentials implements \ArrayAccess
     public static function get_discord_link_channel_id() : ?string
     {
         $val = self::get('discord_link_channel_id');
+        return is_string($val) ? $val : null;
+    }
+
+    /** @return null|string */
+    public static function get_steam_oauth_client_id() : ?string
+    {
+        $val = self::get('steam_oauth_client_id');
+        return is_string($val) ? $val : null;
+    }
+
+    /** @return null|string */
+    public static function get_steam_oauth_client_secret() : ?string
+    {
+        $val = self::get('steam_oauth_client_secret');
+        return is_string($val) ? $val : null;
+    }
+
+    /** @return null|string */
+    public static function get_steam_redirect_uri() : ?string
+    {
+        $val = self::get('steam_redirect_uri');
+        return is_string($val) ? $val : null;
+    }
+
+    /** @return null|string */
+    public static function get_steam_web_api_key() : ?string
+    {
+        $val = self::get('steam_web_api_key');
         return is_string($val) ? $val : null;
     }
 

--- a/meta/config-examples/credentials.ini
+++ b/meta/config-examples/credentials.ini
@@ -50,6 +50,12 @@ discord_bot_token           = "*****"
 discord_verified_role_id    = "*****"
 discord_link_channel_id     = "*****"
 
+; Steam OAuth info; used for login and web API interactions.
+steam_oauth_client_id     = "*****"
+steam_oauth_client_secret = "*****"
+steam_redirect_uri        = "https://example.com/steam/callback"
+steam_web_api_key         = "*****"
+
 ; Kickback Kingdom auth info; used to establish sessions with backend API
 kk_service_key     = "*****"
 


### PR DESCRIPTION
## Summary
- validate steam OAuth credentials and optional Web API key
- expose steam credential getters
- document steam fields in credentials example

## Testing
- `php -l html/Kickback/Backend/Config/ServiceCredentials.php`
- `composer install` *(fails: Required package "openai-php/client" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_b_68a3df016c2c8333b10405fc4d91ee2f