### PR TITLE
feat: add Steam linkage requirement helper

### DIFF
--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -742,16 +742,13 @@ class SocialMediaController
 
     /**
      * Unlink the given account's Steam profile.
-     */
+    */
     public static function unlinkSteamAccount(vAccount $account) : Response
     {
         Session::ensureSessionStarted();
-        if (!Session::readCurrentAccountInto($current) || $current->crand !== $account->crand) {
+        $current = Session::requireSteamLinked();
+        if ($current->crand !== $account->crand) {
             return new Response(false, 'User not logged in', null);
-        }
-
-        if (empty($account->steamUserId)) {
-            return new Response(false, 'No Steam account linked', null);
         }
 
         $conn = Database::getConnection();

--- a/html/Kickback/Services/Session.php
+++ b/html/Kickback/Services/Session.php
@@ -353,6 +353,8 @@ class Session {
 
     /**
      * Ensure the current user is logged in and has a Steam account linked.
+     * This checks the `steamUserId` field on the account and exits with a
+     * failure response if it's missing.
      *
      * @return vAccount The current account if the check passes.
      */


### PR DESCRIPTION
## Summary
- document and expose requireSteamLinked session helper
- use requireSteamLinked within Steam unlink controller logic

## Testing
- `composer install` *(fails: lock file missing openai-php/client)*
- `php -l html/Kickback/Services/Session.php`
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`
- `composer exec phpstan analyse html/Kickback/Services/Session.php html/Kickback/Backend/Controllers/SocialMediaController.php` *(fails: phpstan not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3e1ed69048333940b20ddf53ee215