### PR TITLE
Add Steam linking API endpoints

### DIFF
--- a/html/api/v1/steam/is-linked.php
+++ b/html/api/v1/steam/is-linked.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__.'/../engine/steam/is-linked.php');
+$resp->Return();
+?>

--- a/html/api/v1/steam/link-callback.php
+++ b/html/api/v1/steam/link-callback.php
@@ -1,0 +1,3 @@
+<?php
+require(__DIR__.'/../engine/steam/link-callback.php');
+?>

--- a/html/api/v1/steam/link-start.php
+++ b/html/api/v1/steam/link-start.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__.'/../engine/steam/link-start.php');
+$resp->Return();
+?>

--- a/html/api/v1/steam/unlink.php
+++ b/html/api/v1/steam/unlink.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__.'/../engine/steam/unlink.php');
+$resp->Return();
+?>


### PR DESCRIPTION
## Summary
- Add public Steam API endpoints for link start, callback, unlink, and link status
- Wire endpoints through engine layer to SocialMediaController's Steam linking methods

## Testing
- `php -l html/api/v1/steam/link-start.php`
- `php -l html/api/v1/steam/link-callback.php`
- `php -l html/api/v1/steam/unlink.php`
- `php -l html/api/v1/steam/is-linked.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3e44b2c908333af3fb137bf02b9c1