### PR TITLE
Highlight Steam linking perks and rewards

### DIFF
--- a/html/account-settings.php
+++ b/html/account-settings.php
@@ -123,6 +123,11 @@ $account = Session::getCurrentAccount();
                 .steam-hint {
                     font-size:.875rem; color: var(--bs-secondary-color);
                 }
+                .steam-callout {
+                    background: linear-gradient(90deg, rgba(0,173,238,.12), rgba(32,34,37,.05));
+                    border: 1px solid rgba(0,173,238,.25);
+                    border-radius: .75rem; padding: .75rem .9rem;
+                }
                 </style>
 
                 <div class="card mb-4 providers-card">
@@ -205,7 +210,7 @@ $account = Session::getCurrentAccount();
                             <i class="fa-brands fa-steam"></i> Steam
                         </div>
                         <div class="steam-hint">
-                            Add your Steam to show game links and let friends find you faster.
+                            Link your Steam to unlock exclusive raffles, showcase your games, and let allies find you faster.
                         </div>
                         </div>
 
@@ -237,6 +242,21 @@ $account = Session::getCurrentAccount();
                         <div class="fw-semibold"><?= htmlspecialchars($account->steamUsername); ?></div>
                         <div class="small text-muted">Steam account linked.</div>
                         </div>
+                        <div class="steam-callout mt-3 d-flex align-items-start gap-2">
+                        <i class="fa-solid fa-scroll mt-1"></i>
+                        <div class="small">Your Steam banner now flies in the Kingdom. Watch the town board for your exclusive draws.</div>
+                        </div>
+                    <?php } else { ?>
+                        <div class="steam-callout mt-3 d-flex align-items-start gap-2">
+                        <i class="fa-solid fa-ticket mt-1"></i>
+                        <div class="small"><strong>Steam Raffles Await</strong> — Link your Steam to earn raffle entries, flaunt your game library, and unlock surprise rewards.</div>
+                        </div>
+
+                        <ul class="mt-3 mb-0 small text-muted d-flex flex-wrap gap-2 list-unstyled">
+                        <li class="perk-chip"><i class="fa-solid fa-ticket"></i> Entry to Steam raffles</li>
+                        <li class="perk-chip"><i class="fa-solid fa-gamepad"></i> Share your game library</li>
+                        <li class="perk-chip"><i class="fa-solid fa-bolt"></i> Quick-join Kickback servers</li>
+                        </ul>
                     <?php } ?>
                     </section>
 


### PR DESCRIPTION
## Summary
- introduce steam callout styling for reward messaging
- expand steam linking UI with raffle perks and motivational copy

## Testing
- `php -l html/account-settings.php`

------
https://chatgpt.com/codex/tasks/task_b_68a3ed13979883338bee324c60aff4d9