### PR TITLE
Build Discord redirect URI from host

### DIFF
--- a/html/Kickback/Backend/Config/ServiceCredentials.php
+++ b/html/Kickback/Backend/Config/ServiceCredentials.php
@@ -178,7 +178,12 @@ final class ServiceCredentials implements \ArrayAccess
         // Discord OAuth info; used for login and guild interactions.
         $error_count += (int)!$this->credential_string_exists       ("discord_oauth_client_id");
         $error_count += (int)!$this->credential_string_exists       ("discord_oauth_client_secret");
-        $error_count += (int)!$this->credential_of_given_type_exists("discord_redirect_uri", "URL", FILTER_VALIDATE_URL);
+
+        $envRedirect = getenv('DISCORD_REDIRECT_URI');
+        if ($envRedirect === false || filter_var($envRedirect, FILTER_VALIDATE_URL) === false) {
+            $error_count += (int)!$this->credential_of_given_type_exists("discord_redirect_uri", "URL", FILTER_VALIDATE_URL);
+        }
+
         $error_count += (int)!$this->credential_string_exists       ("discord_guild_id");
         $error_count += (int)!$this->credential_string_exists       ("discord_bot_token");
         $error_count += (int)!$this->credential_string_exists       ("discord_verified_role_id");
@@ -325,6 +330,11 @@ final class ServiceCredentials implements \ArrayAccess
     /** @return null|string */
     public static function get_discord_redirect_uri() : ?string
     {
+        $env = getenv('DISCORD_REDIRECT_URI');
+        if (is_string($env) && $env !== '') {
+            return $env;
+        }
+
         $val = self::get('discord_redirect_uri');
         return is_string($val) ? $val : null;
     }

--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -7,6 +7,7 @@ use Kickback\Backend\Config\ServiceCredentials;
 use Kickback\Backend\Models\Response;
 use Kickback\Backend\Views\vAccount;
 use Kickback\Backend\Views\vRecordId;
+use Kickback\Common\Version;
 use Kickback\Services\Database;
 use Kickback\Services\Session;
 
@@ -343,6 +344,23 @@ class SocialMediaController
     }
 
     /**
+     * Build the Discord OAuth redirect callback URL from the configured base.
+     */
+    private static function discordRedirectUri() : ?string
+    {
+        $base = ServiceCredentials::get_discord_redirect_uri();
+        if (!$base) {
+            return null;
+        }
+        $base = rtrim($base, '/');
+        $beta = Version::urlBetaPrefix();
+        if ($beta !== '' && !str_ends_with($base, $beta)) {
+            $base .= $beta;
+        }
+        return $base . '/api/v1/discord/link-callback.php';
+    }
+
+    /**
      * Start the Discord OAuth linking process.
      *
      * @return Response Contains the Discord authorization URL on success.
@@ -355,7 +373,7 @@ class SocialMediaController
         }
 
         $clientId    = ServiceCredentials::get_discord_oauth_client_id();
-        $redirectUri = ServiceCredentials::get_discord_redirect_uri();
+        $redirectUri = self::discordRedirectUri();
         if (!$clientId || !$redirectUri) {
             return new Response(false, 'Discord OAuth not configured', null);
         }
@@ -393,7 +411,7 @@ class SocialMediaController
 
         $clientId     = ServiceCredentials::get_discord_oauth_client_id();
         $clientSecret = ServiceCredentials::get_discord_oauth_client_secret();
-        $redirectUri  = ServiceCredentials::get_discord_redirect_uri();
+        $redirectUri  = self::discordRedirectUri();
         if (!$clientId || !$clientSecret || !$redirectUri) {
             return new Response(false, 'Discord OAuth not configured', null);
         }

--- a/meta/config-examples/credentials.ini
+++ b/meta/config-examples/credentials.ini
@@ -44,7 +44,10 @@ discord_api_key    = "*****"
 ; Discord OAuth info; used for login and guild interactions.
 discord_oauth_client_id     = "*****"
 discord_oauth_client_secret = "*****"
-discord_redirect_uri        = "https://example.com/discord/callback"
+; Base URL for Discord callback. May include a path such as "/beta".
+; Runtime appends the callback path if needed.
+; Can alternatively be supplied via DISCORD_REDIRECT_URI environment variable.
+discord_redirect_uri        = "https://example.com"
 discord_guild_id            = "*****"
 discord_bot_token           = "*****"
 discord_verified_role_id    = "*****"


### PR DESCRIPTION
## Summary
- Construct Discord redirect URL from a configurable base, appending the beta prefix only when missing.
- Reuse the built callback URL for both start and completion of the OAuth flow.
- Document that `discord_redirect_uri` may include a path such as `/beta`.

## Testing
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`
- `php -l html/Kickback/Backend/Config/ServiceCredentials.php`
- `php -l meta/config-examples/credentials.ini`


------
https://chatgpt.com/codex/tasks/task_b_68a50723e7a08333b5938b41c04c264a