### PR TITLE
Ensure session cookies use root path and kickback-kingdom.com domain

### DIFF
--- a/html/Kickback/Services/Session.php
+++ b/html/Kickback/Services/Session.php
@@ -408,6 +408,10 @@ class Session {
     public static function ensureSessionStarted() : void
     {
         if (\session_status() !== PHP_SESSION_ACTIVE) {
+            \session_set_cookie_params([
+                'path' => '/',
+                'domain' => '.kickback-kingdom.com',
+            ]);
             \session_start();
         }
     }


### PR DESCRIPTION
## Summary
- Ensure sessions start with cookie parameters for path `/` and domain `.kickback-kingdom.com`

## Testing
- `composer install --no-interaction` *(fails: Required package "openai-php/client" is not present in the lock file)*
- `php -l html/Kickback/Services/Session.php`
- `php -r "require 'html/Kickback/Services/Session.php'; \Kickback\Services\Session::ensureSessionStarted(); var_export(session_get_cookie_params());"`
- `curl -H 'Host: kickback-kingdom.com' -c /tmp/cookie.txt 'http://127.0.0.1:8000/testsession.php?set=1'` & `curl -H 'Host: kickback-kingdom.com' -b /tmp/cookie.txt 'http://127.0.0.1:8000/beta/testsession.php'`


------
https://chatgpt.com/codex/tasks/task_b_68a50a8fd7c8833396359be47069bcb1