### PR TITLE
Log Discord OAuth state mismatch

### DIFF
--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -406,6 +406,15 @@ class SocialMediaController
 
         $expectedState = Session::sessionDataString('discord_oauth_state');
         if (!$expectedState || $expectedState !== $state) {
+            $sessionId = Session::getCurrentSessionId();
+            $username = $account->username ?? 'unknown';
+            error_log(
+                'completeDiscordLink invalid state token: session='
+                . ($sessionId ?? 'none')
+                . ' user=' . $username
+                . ' expected=' . ($expectedState ?? 'none')
+                . ' received=' . $state
+            );
             return new Response(false, 'Invalid state token', null);
         }
 


### PR DESCRIPTION
## Summary
- Log expected and received Discord OAuth state tokens with session and user info

## Testing
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`
- `curl -I https://kickback-kingdom.com/beta` *(fails: CONNECT tunnel failed)*
- `tail -n 20 /var/log/nginx/error.log` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a50b8ef094833388a66c5b60bfeab1