### PR TITLE
Make session cookie domain configurable

### DIFF
--- a/html/Kickback/Backend/Config/ServiceCredentials.php
+++ b/html/Kickback/Backend/Config/ServiceCredentials.php
@@ -314,6 +314,13 @@ final class ServiceCredentials implements \ArrayAccess
     }
 
     /** @return null|string */
+    public static function get_session_cookie_domain() : ?string
+    {
+        $val = self::get('session_cookie_domain');
+        return is_string($val) ? $val : null;
+    }
+
+    /** @return null|string */
     public static function get_discord_oauth_client_id() : ?string
     {
         $val = self::get('discord_oauth_client_id');

--- a/html/Kickback/Services/Session.php
+++ b/html/Kickback/Services/Session.php
@@ -408,10 +408,30 @@ class Session {
     public static function ensureSessionStarted() : void
     {
         if (\session_status() !== PHP_SESSION_ACTIVE) {
-            \session_set_cookie_params([
+            $cookieParams = [
                 'path' => '/',
-                'domain' => '.kickback-kingdom.com',
-            ]);
+            ];
+
+            $domain = ServiceCredentials::get_session_cookie_domain();
+            if (!is_string($domain) || $domain === '') {
+                $host = $_SERVER['HTTP_HOST'] ?? '';
+                if ($host !== '') {
+                    $host = explode(':', $host)[0];
+                    $parts = explode('.', $host);
+                    if (count($parts) >= 2) {
+                        $root = implode('.', array_slice($parts, -2));
+                        if ($root === 'kickback-kingdom.com') {
+                            $domain = '.' . $root;
+                        }
+                    }
+                }
+            }
+
+            if (is_string($domain) && $domain !== '') {
+                $cookieParams['domain'] = $domain;
+            }
+
+            \session_set_cookie_params($cookieParams);
             \session_start();
         }
     }

--- a/meta/config-examples/credentials.ini
+++ b/meta/config-examples/credentials.ini
@@ -62,6 +62,9 @@ steam_web_api_key         = "*****"
 ; Kickback Kingdom auth info; used to establish sessions with backend API
 kk_service_key     = "*****"
 
+; Optional session cookie domain for sharing sessions across subdomains
+; session_cookie_domain = ".kickback-kingdom.com"
+
 ; key for https://ipinfo.io/ used for analytics information
 ipinfo_api_key         = "*****"
 


### PR DESCRIPTION
## Summary
- Allow Session to set cookie domain from ServiceCredentials or HTTP_HOST
- Add ServiceCredentials helper for optional session cookie domain
- Document optional `session_cookie_domain` in credentials example

## Testing
- `php -l html/Kickback/Services/Session.php`
- `php -l html/Kickback/Backend/Config/ServiceCredentials.php`
- `curl -i -c /tmp/cookies.txt http://localhost:8000/api/v1/discord/link-start.php`
- `curl -v -b /tmp/cookies.txt "http://localhost:8000/api/v1/discord/link-callback.php?code=dummy&state=dummy"`


------
https://chatgpt.com/codex/tasks/task_b_68a51e7234e48333a4d9201825c399e0