### PR TITLE
Use generic error message for invalid Discord link state

### DIFF
--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -414,7 +414,7 @@ class SocialMediaController
                 . ' expected=' . ($expectedState ?? 'none')
                 . ' received=' . $state;
             error_log($msg);
-            return new Response(false, $msg, null);
+            return new Response(false, 'Invalid state token; please restart the Discord link process.', null);
         }
 
         $clientId     = ServiceCredentials::get_discord_oauth_client_id();

--- a/html/account-settings.php
+++ b/html/account-settings.php
@@ -357,9 +357,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const params = new URLSearchParams(window.location.search);
         const discordError = params.get('discord_error');
         if (discordError) {
+            const userMessage = discordError || 'Invalid state token; please restart the Discord link process.';
             const statusDiv = $('#discordStatus');
-            statusDiv.removeClass('d-none alert-success').addClass('alert-danger').text(discordError);
-            ShowPopError(discordError, 'Discord');
+            statusDiv.removeClass('d-none alert-success').addClass('alert-danger').text(userMessage);
+            ShowPopError(userMessage, 'Discord');
             params.delete('discord_error');
             const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
             history.replaceState({}, '', newUrl);


### PR DESCRIPTION
## Summary
- Return a user-friendly message when the Discord OAuth state token is invalid while keeping detailed logging
- Have account settings page surface the generic Discord linking error text

## Testing
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`
- `php -l html/account-settings.php`
- `composer install` *(fails: Required package "openai-php/client" is not present in the lock file)*
- `./meta/phpstan.sh` *(fails: Could not open input file: ./meta/../html/vendor/composer/phpstan/phpstan/phpstan)*


------
https://chatgpt.com/codex/tasks/task_b_68a520653ac4833398e59fcc772327bb