### PR TITLE
Ensure Discord redirect URI uses active host when unset

### DIFF
--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -350,7 +350,12 @@ class SocialMediaController
     {
         $base = ServiceCredentials::get_discord_redirect_uri();
         if (!$base) {
-            return null;
+            $host = $_SERVER['HTTP_HOST'] ?? null;
+            if (!$host) {
+                return null;
+            }
+            $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+            $base   = $scheme . '://' . $host;
         }
         $base = rtrim($base, '/');
         $beta = Version::urlBetaPrefix();

--- a/meta/config-examples/credentials.ini
+++ b/meta/config-examples/credentials.ini
@@ -47,6 +47,7 @@ discord_oauth_client_secret = "*****"
 ; Base URL for Discord callback. May include a path such as "/beta".
 ; Runtime appends the callback path if needed.
 ; Can alternatively be supplied via DISCORD_REDIRECT_URI environment variable.
+; If configured, DISCORD_REDIRECT_URI should match the active environment's base URL.
 discord_redirect_uri        = "https://example.com"
 discord_guild_id            = "*****"
 discord_bot_token           = "*****"


### PR DESCRIPTION
## Summary
- build Discord OAuth callback URL from request host when `DISCORD_REDIRECT_URI` is unset
- document that `DISCORD_REDIRECT_URI` should match the environment's base URL

## Testing
- `composer install` (fails: Required package "openai-php/client" is not present in the lock file)
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`


------
https://chatgpt.com/codex/tasks/task_b_68a524f518608333ab80cb261491f35b