### PR TITLE
Ensure Discord cURL calls use CA bundle

### DIFF
--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -281,6 +281,7 @@ class SocialMediaController
         ]);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        self::applyCaBundle($ch);
         curl_exec($ch);
         curl_close($ch);
     }
@@ -314,6 +315,7 @@ class SocialMediaController
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
                 curl_setopt($ch, CURLOPT_POSTFIELDS, $denyPayload);
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                self::applyCaBundle($ch);
                 curl_exec($ch);
                 curl_close($ch);
             }
@@ -337,6 +339,7 @@ class SocialMediaController
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
                 curl_setopt($ch, CURLOPT_POSTFIELDS, $allowPayload);
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                self::applyCaBundle($ch);
                 curl_exec($ch);
                 curl_close($ch);
             }


### PR DESCRIPTION
## Summary
- apply CA bundle when removing verified Discord role
- apply CA bundle when setting channel permissions for @everyone and verified role

## Testing
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`


------
https://chatgpt.com/codex/tasks/task_b_68a52c89bb8483338a5114669c4c39ed