### PR TITLE
Refactor Discord webhook error handling

### DIFF
--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -81,7 +81,7 @@ class SocialMediaController
         return ['status' => $status, 'body' => $body, 'error' => $error];
     }
 
-    public static function DiscordWebHook(mixed $msg) : void
+    public static function DiscordWebHook(mixed $msg) : bool
     {
         $kk_credentials = ServiceCredentials::instance();
 
@@ -90,8 +90,11 @@ class SocialMediaController
 
         $result = self::discordApiRequest('POST', $webhookURL, ['content' => $msg]);
         if ($result['body'] === false) {
-            echo 'Error:' . ($result['error'] ?? 'unknown');
+            error_log('Discord webhook error: ' . ($result['error'] ?? 'unknown'));
+            return false;
         }
+
+        return true;
     }
 
     private static function sendChannelMessage(string $channelId, string $message) : void


### PR DESCRIPTION
## Summary
- Replace `echo` with `error_log` in `SocialMediaController::DiscordWebHook`
- Return boolean indicating success or failure instead of outputting errors

## Testing
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`
- `composer install` *(fails: Required package "openai-php/client" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_b_68a5307a4a348333a381221b4d5f47ce