### PR TITLE
Rename DiscordWebHook to sendDiscordWebhook

### DIFF
--- a/html/Kickback/Backend/Controllers/AccountController.php
+++ b/html/Kickback/Backend/Controllers/AccountController.php
@@ -1317,7 +1317,7 @@ class AccountController
     
             // Additional actions within the transaction
             LootController::giveWritOfPassage($login);
-            SocialMediaController::DiscordWebHook(FlavorTextController::getNewcomerIntroduction($username));
+            SocialMediaController::sendDiscordWebhook(FlavorTextController::getNewcomerIntroduction($username));
     
             // Commit transaction
             $conn->commit();

--- a/html/Kickback/Backend/Controllers/BlogPostController.php
+++ b/html/Kickback/Backend/Controllers/BlogPostController.php
@@ -168,7 +168,7 @@ class BlogPostController
         if ($success) {
             // Send the blog post announcement via Discord webhook
             $msg = FlavorTextController::getNewBlogPostAnnouncement($currentBlogPost);
-            SocialMediaController::DiscordWebHook($msg);
+            SocialMediaController::sendDiscordWebhook($msg);
 
             return new Response(true, "Blog post published successfully!", null);
         } else {

--- a/html/Kickback/Backend/Controllers/QuestController.php
+++ b/html/Kickback/Backend/Controllers/QuestController.php
@@ -551,7 +551,7 @@ class QuestController
 
                 $raffleWinner = $raffleWinnerResp->data;
                 $msg = FlavorTextController::getRaffleWinnerAnnouncement($raffleQuest->title, $raffleWinner["Username"]);
-                SocialMediaController::DiscordWebHook($msg);
+                SocialMediaController::sendDiscordWebhook($msg);
 
                 return new Response(true, "Selected Raffle Winner!", null);
             } else {
@@ -1001,7 +1001,7 @@ class QuestController
             if (!self::queryQuestByIdInto($quest_id, $quest)) {
                 return new Response(false, "Could not find quest with that ID; failed to register for quest.", null);
             }
-            SocialMediaController::DiscordWebHook(FlavorTextController::getRandomGreeting() . ', ' . $account->username . ' just signed up for the ' . $quest->title . ' quest.');
+            SocialMediaController::sendDiscordWebhook(FlavorTextController::getRandomGreeting() . ', ' . $account->username . ' just signed up for the ' . $quest->title . ' quest.');
             mysqli_stmt_close($stmt);
             return (new Response(true, "Registered for quest successfully", null));
         } else {

--- a/html/Kickback/Backend/Controllers/SocialMediaController.php
+++ b/html/Kickback/Backend/Controllers/SocialMediaController.php
@@ -81,7 +81,7 @@ class SocialMediaController
         return ['status' => $status, 'body' => $body, 'error' => $error];
     }
 
-    public static function DiscordWebHook(mixed $msg) : bool
+    public static function sendDiscordWebhook(mixed $msg) : bool
     {
         $kk_credentials = ServiceCredentials::instance();
 
@@ -473,7 +473,7 @@ class SocialMediaController
             $mention = "<@{$account->discordUserId}>";
             $message = FlavorTextController::getDiscordLinkFlavorText($mention);
             //self::sendChannelMessage($channelId, $message);
-            //self::DiscordWebHook($message);
+            //self::sendDiscordWebhook($message);
         }
     }
 
@@ -587,7 +587,7 @@ class SocialMediaController
             $mention = "<@{$account->discordUserId}>";
             $message = FlavorTextController::getDiscordUnlinkFlavorText($mention);
             //self::sendChannelMessage($channelId, $message);
-            //self::DiscordWebHook($message);
+            //self::sendDiscordWebhook($message);
         }
 
         $account->discordUserId = null;

--- a/html/admin-lord-sedwyn.php
+++ b/html/admin-lord-sedwyn.php
@@ -83,7 +83,7 @@ $webhookURL = $kk_credentials["discord_api_url"] . '/' . $kk_credentials["discor
                 if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["msg"])) {
                     $msg = trim($_POST["msg"]);
                     if ($msg !== "") {
-                        SocialMediaController::DiscordWebHook($msg);
+                        SocialMediaController::sendDiscordWebhook($msg);
                         echo '<div class="alert alert-success mt-3" role="alert">';
                         echo '<strong>Message sent:</strong> ' . htmlspecialchars($msg);
                         echo '</div>';

--- a/html/quest.php
+++ b/html/quest.php
@@ -93,7 +93,7 @@ if (isset($_POST["submit-raffle"]))
             if ($thisQuest->reviewStatus->published)
             {
 
-                SocialMediaController::DiscordWebHook(FlavorTextController::getRandomGreeting().', '.Session::getCurrentAccount()->username.' just submitted a number of raffle tickets to the '.$thisQuest->title.' quest.');
+                SocialMediaController::sendDiscordWebhook(FlavorTextController::getRandomGreeting().', '.Session::getCurrentAccount()->username.' just submitted a number of raffle tickets to the '.$thisQuest->title.' quest.');
             }
 
             $hasSuccess = true;


### PR DESCRIPTION
## Summary
- rename `DiscordWebHook` to camelCase `sendDiscordWebhook`
- update all call sites in controllers and pages to use new method name

## Testing
- `php -l html/Kickback/Backend/Controllers/SocialMediaController.php`
- `php -l html/quest.php`
- `php -l html/admin-lord-sedwyn.php`
- `php -l html/Kickback/Backend/Controllers/AccountController.php`
- `php -l html/Kickback/Backend/Controllers/BlogPostController.php`
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `composer install` *(fails: Required package "openai-php/client" is not present in the lock file)*


------
https://chatgpt.com/codex/tasks/task_b_68a53116d2d883339fdb885d70746991