### PR TITLE
Move Steam linking logic to dedicated SteamController

### DIFF
--- a/html/Kickback/Backend/Controllers/SteamController.php
+++ b/html/Kickback/Backend/Controllers/SteamController.php
@@ -9,7 +9,7 @@ use Kickback\Backend\Views\vAccount;
 use Kickback\Services\Database;
 use Kickback\Services\Session;
 
-class SocialMediaController
+class SteamController
 {
     use CurlHelper;
 
@@ -18,7 +18,7 @@ class SocialMediaController
      *
      * @return Response Contains the Steam OpenID URL on success.
      */
-    public static function startSteamLink() : Response
+    public static function startLink() : Response
     {
         Session::ensureSessionStarted();
         if (!Session::isLoggedIn()) {
@@ -54,7 +54,7 @@ class SocialMediaController
      *
      * @param array<string,string> $query The OpenID response query parameters.
      */
-    public static function completeSteamLink(array $query) : Response
+    public static function completeLink(array $query) : Response
     {
         Session::ensureSessionStarted();
         if (!Session::readCurrentAccountInto($account)) {
@@ -142,7 +142,7 @@ class SocialMediaController
     /**
      * Check if a Steam account is already linked.
      */
-    public static function isSteamLinked(string $steamId) : Response
+    public static function isLinked(string $steamId) : Response
     {
         Session::ensureSessionStarted();
         $conn = Database::getConnection();
@@ -162,7 +162,7 @@ class SocialMediaController
     /**
      * Unlink the given account's Steam profile.
      */
-    public static function unlinkSteamAccount(vAccount $account) : Response
+    public static function unlink(vAccount $account) : Response
     {
         Session::ensureSessionStarted();
         $current = Session::requireSteamLinked();

--- a/html/api/v1/engine/steam/is-linked.php
+++ b/html/api/v1/engine/steam/is-linked.php
@@ -1,7 +1,7 @@
 <?php
 require(__DIR__.'/../../engine/engine.php');
 
-use Kickback\Backend\Controllers\SocialMediaController;
+use Kickback\Backend\Controllers\SteamController;
 use Kickback\Backend\Models\Response;
 
 OnlyGET();
@@ -11,5 +11,5 @@ if (!$steamId) {
     return new Response(false, 'Missing Steam user ID', null);
 }
 
-return SocialMediaController::isSteamLinked($steamId);
+return SteamController::isLinked($steamId);
 ?>

--- a/html/api/v1/engine/steam/link-callback.php
+++ b/html/api/v1/engine/steam/link-callback.php
@@ -1,12 +1,12 @@
 <?php
 require(__DIR__.'/../../engine/engine.php');
 
-use Kickback\Backend\Controllers\SocialMediaController;
+use Kickback\Backend\Controllers\SteamController;
 use Kickback\Common\Version;
 
 OnlyGET();
 
-$resp = SocialMediaController::completeSteamLink($_GET);
+$resp = SteamController::completeLink($_GET);
 
 if ($resp->success) {
     header('Location: '.Version::urlBetaPrefix().'/account-settings.php');

--- a/html/api/v1/engine/steam/link-start.php
+++ b/html/api/v1/engine/steam/link-start.php
@@ -1,9 +1,9 @@
 <?php
 require(__DIR__.'/../../engine/engine.php');
 
-use Kickback\Backend\Controllers\SocialMediaController;
+use Kickback\Backend\Controllers\SteamController;
 
 OnlyGET();
 
-return SocialMediaController::startSteamLink();
+return SteamController::startLink();
 ?>

--- a/html/api/v1/engine/steam/unlink.php
+++ b/html/api/v1/engine/steam/unlink.php
@@ -1,11 +1,11 @@
 <?php
 require(__DIR__.'/../../engine/engine.php');
 
-use Kickback\Backend\Controllers\SocialMediaController;
+use Kickback\Backend\Controllers\SteamController;
 use Kickback\Services\Session;
 
 OnlyPOST();
 
 $account = Session::requireSteamLinked();
-return SocialMediaController::unlinkSteamAccount($account);
+return SteamController::unlink($account);
 ?>


### PR DESCRIPTION
## Summary
- add `SteamController` for Steam OpenID link, completion, status and unlink operations
- point Steam API entrypoints to the new controller and drop `SocialMediaController`

## Testing
- `php -l html/Kickback/Backend/Controllers/SteamController.php`
- `php -l html/api/v1/engine/steam/link-start.php`
- `php -l html/api/v1/engine/steam/link-callback.php`
- `php -l html/api/v1/engine/steam/is-linked.php`
- `php -l html/api/v1/engine/steam/unlink.php`
- `composer dump-autoload`


------
https://chatgpt.com/codex/tasks/task_b_68a535147ed083339ecfbc3824cfbbbe