### PR TITLE
Detect HTTPS via forwarded headers for Discord OAuth callback

### DIFF
--- a/html/Kickback/Backend/Controllers/DiscordController.php
+++ b/html/Kickback/Backend/Controllers/DiscordController.php
@@ -279,8 +279,18 @@ class DiscordController
             if (!$host) {
                 return null;
             }
-            $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
-            $base   = $scheme . '://' . $host;
+
+            $scheme = 'http';
+            $forwarded = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '';
+            $forwarded = explode(',', (string)$forwarded)[0];
+            if (
+                (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+                || strcasecmp($forwarded, 'https') === 0
+            ) {
+                $scheme = 'https';
+            }
+
+            $base = $scheme . '://' . $host;
         }
         $base = rtrim($base, '/');
         $beta = Version::urlBetaPrefix();


### PR DESCRIPTION
## Summary
- Detect HTTPS via `HTTP_X_FORWARDED_PROTO` when building Discord OAuth redirect URL

## Testing
- `php -l html/Kickback/Backend/Controllers/DiscordController.php`
- `./meta/phpstan.sh` *(fails: Could not open input file: ./meta/../html/vendor/composer/phpstan/phpstan/phpstan)*
- `composer install` *(fails: Required package "openai-php/client" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_b_68a53948664483338294e364fe89bc85