### PR TITLE
Generalize session cookie domain handling

### DIFF
--- a/html/Kickback/Services/Session.php
+++ b/html/Kickback/Services/Session.php
@@ -417,11 +417,11 @@ class Session {
                 $host = $_SERVER['HTTP_HOST'] ?? '';
                 if ($host !== '') {
                     $host = explode(':', $host)[0];
-                    $parts = explode('.', $host);
-                    if (count($parts) >= 2) {
-                        $root = implode('.', array_slice($parts, -2));
-                        if ($root === 'kickback-kingdom.com') {
-                            $domain = '.' . $root;
+                    // Ignore numeric/IP and localhost hosts
+                    if (!filter_var($host, FILTER_VALIDATE_IP) && $host !== 'localhost') {
+                        $parts = explode('.', $host);
+                        if (count($parts) >= 2) {
+                            $domain = '.' . implode('.', array_slice($parts, -2));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Automatically derive the session cookie domain from the host when not configured, ensuring sessions persist across subdomains.

## Testing
- `php -l html/Kickback/Services/Session.php`


------
https://chatgpt.com/codex/tasks/task_b_68a60c0e9d40833393ea552453504864