### PR TITLE
Use Session service to start session

### DIFF
--- a/html/Kickback/Common/Utility/FormToken.php
+++ b/html/Kickback/Common/Utility/FormToken.php
@@ -15,15 +15,14 @@ namespace Kickback\Common\Utility;
 //   other people to make mistakes, and it makes the code harder to understand.)
 //   -- Lily Joan  2024-08-10
 use Kickback\Backend\Models\Response;
+use Kickback\Services\Session;
 
 class FormToken {
     /**
      * Generates a new form token and stores it in the session.
      */
     public static function generateFormToken() : void {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
+        Session::ensureSessionStarted();
 
         if (!isset($_SESSION['form_token']) || !is_string($_SESSION['form_token']) || strlen($_SESSION['form_token']) !== 64) {
             $_SESSION['form_token'] = bin2hex(random_bytes(32));
@@ -37,9 +36,7 @@ class FormToken {
      * @return Response Returns an Response indicating the success or failure of the token validation.
      */
     public static function useFormToken() {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
+        Session::ensureSessionStarted();
 
         if (isset($_POST['form_token']) && isset($_SESSION['form_token']) && $_SESSION['form_token'] === $_POST['form_token']) {
             // Regenerate a new token to ensure a token is only used once


### PR DESCRIPTION
## Summary
- ensure sessions start through central Session service in form token utility

## Testing
- `php -l html/Kickback/Common/Utility/FormToken.php`
- `composer exec phpstan -- analyse --no-progress --error-format=raw html/Kickback/Common/Utility/FormToken.php` *(fails: phpstan not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a60c0e9d40833393ea552453504864