### PR TITLE
Improve Discord linking error messages

### DIFF
--- a/html/account-settings.php
+++ b/html/account-settings.php
@@ -358,8 +358,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const discordError = params.get('discord_error');
         if (discordError) {
             const messages = {
-                'state-missing': 'Session expired or cookies were cleared. Please log in again.',
-                'state-mismatch': 'Link process interrupted (multiple tabs or domain change). Try linking once more.'
+                'state-missing': 'We could not verify your session. Please ensure you are logged in and cookies are enabled, then try linking again.',
+                'state-mismatch': 'Link process interrupted (multiple tabs or domain change). Try linking once more.',
+                'User not logged in': 'Please sign in to link your Discord account.'
             };
             const userMessage = messages[discordError] || discordError;
             const statusDiv = $('#discordStatus');


### PR DESCRIPTION
## Summary
- clarify Discord linking failures when session state missing
- prompt users to log in and enable cookies or retry when link is interrupted

## Testing
- `php -l html/account-settings.php`
- `composer exec phpstan analyse` *(fails: phpstan: not found)*
- `composer install` *(fails: Required package "openai-php/client" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_b_68a616c5fd088333bfc318f096a11194