### PR TITLE
Add hexagon cropper aspect ratio option

### DIFF
--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -270,6 +270,7 @@ if ($betaPrefix !== '' && strncmp($redirectUri, $betaPrefix . '/', strlen($betaP
                                     <option value=".26">Desktop Banner</option>
                                     <option value=".463">Mobile Banner</option>
                                     <option value="1">Icon (Square)</option>
+                                    <option value="1.1547">Hexagon</option>
                                     <option value="0">Custom</option>
                                 </select>
                             </div>


### PR DESCRIPTION
## Summary
- Add a predefined Hexagon aspect ratio to the media upload cropper so images can fill hex-shaped frames

## Testing
- `composer install`
- `php -l html/php-components/base-page-components.php`


------
https://chatgpt.com/codex/tasks/task_b_68a64ee626e08333b8411486d6f698de