### PR TITLE
Add copy button for AI image prompts

### DIFF
--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -221,7 +221,10 @@ if ($betaPrefix !== '' && strncmp($redirectUri, $betaPrefix . '/', strlen($betaP
                             </div>
                             <div class="mb-3">
                                 <label for="imagePrompt" class="form-label">Prompt</label>
-                                <textarea id="imagePrompt" class="form-control" rows="3"></textarea>
+                                <div class="input-group">
+                                    <textarea id="imagePrompt" class="form-control" rows="3"></textarea>
+                                    <button class="btn btn-outline-secondary" type="button" onclick="copyImagePrompt()">Copy</button>
+                                </div>
                             </div>
                             <div class="mb-3">
                                 <label for="imagePromptDescription" class="form-label">Description</label>

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -271,6 +271,15 @@ function GeneratePromptImage(prompt)
         console.error('Generation error', err);
     });
 }
+function copyImagePrompt()
+{
+    const promptEl = document.getElementById('imagePrompt');
+    if (promptEl) {
+        navigator.clipboard.writeText(promptEl.value)
+            .then(() => alert('Prompt copied!'));
+    }
+}
+window.copyImagePrompt = copyImagePrompt;
 window.GenerateImageFromPrompt = GeneratePromptImage;
 window.PromptGenerateWithAI = PromptGenerateWithAI;
 <?php } ?>


### PR DESCRIPTION
## Summary
- Add copy button next to the AI image prompt field
- Provide copyImagePrompt helper with clipboard copy & confirmation

## Testing
- `php -l html/php-components/base-page-components.php`
- `php -l html/php-components/select-media.php`


------
https://chatgpt.com/codex/tasks/task_b_68a65564d6b48333b3baebacccfb0029