### PR TITLE
feat: allow using generated prompts as custom text

### DIFF
--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -224,6 +224,7 @@ if ($betaPrefix !== '' && strncmp($redirectUri, $betaPrefix . '/', strlen($betaP
                                 <div class="input-group">
                                     <textarea id="imagePrompt" class="form-control" rows="3"></textarea>
                                     <button class="btn btn-outline-secondary" type="button" onclick="copyImagePrompt()">Copy</button>
+                                    <button id="usePromptAsCustom" class="btn btn-outline-secondary d-none" type="button" onclick="usePromptAsCustom()">Use as custom</button>
                                 </div>
                             </div>
                             <div class="mb-3">

--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -84,6 +84,7 @@ function updatePromptPreview() {
     const sceneryEl = document.getElementById('imagePromptScenery');
     const factionEl = document.getElementById('imagePromptFaction');
     const promptEl = document.getElementById('imagePrompt');
+    const useCustomBtn = document.getElementById('usePromptAsCustom');
     const template = templateEl ? templateEl.value : '';
     const description = descriptionEl ? descriptionEl.value : '';
     const scenery = sceneryEl ? sceneryEl.value : '';
@@ -96,10 +97,16 @@ function updatePromptPreview() {
             promptEl.value = finalPrompt;
             promptEl.readOnly = true;
             promptDirty = false;
+            if (useCustomBtn) {
+                useCustomBtn.classList.remove('d-none');
+            }
         } else {
             promptEl.readOnly = false;
             if (!promptDirty) {
                 promptEl.value = finalPrompt;
+            }
+            if (useCustomBtn) {
+                useCustomBtn.classList.add('d-none');
             }
         }
     }
@@ -276,12 +283,39 @@ function copyImagePrompt()
     const promptEl = document.getElementById('imagePrompt');
     if (promptEl) {
         navigator.clipboard.writeText(promptEl.value)
-            .then(() => alert('Prompt copied!'));
+            .then(() => {
+                alert('Prompt copied!');
+                const templateEl = document.getElementById('imagePromptTemplate');
+                const useCustomBtn = document.getElementById('usePromptAsCustom');
+                if (templateEl && templateEl.value && useCustomBtn) {
+                    useCustomBtn.classList.remove('d-none');
+                }
+            });
+    }
+}
+function usePromptAsCustom() {
+    const templateEl = document.getElementById('imagePromptTemplate');
+    const promptEl = document.getElementById('imagePrompt');
+    const useCustomBtn = document.getElementById('usePromptAsCustom');
+    if (templateEl) {
+        templateEl.value = '';
+        promptDirty = true;
+        templateEl.dispatchEvent(new Event('change'));
+    } else {
+        promptDirty = true;
+        updatePromptPreview();
+    }
+    if (promptEl) {
+        promptEl.readOnly = false;
+    }
+    if (useCustomBtn) {
+        useCustomBtn.classList.add('d-none');
     }
 }
 window.copyImagePrompt = copyImagePrompt;
 window.GenerateImageFromPrompt = GeneratePromptImage;
 window.PromptGenerateWithAI = PromptGenerateWithAI;
+window.usePromptAsCustom = usePromptAsCustom;
 <?php } ?>
 function OpenMediaUploadModal()
 {


### PR DESCRIPTION
## Summary
- show "Use as custom" button when prompts are generated from a template
- convert templated prompts to editable custom text on request
- prevent template previews from overwriting user-edited custom prompts

## Testing
- `php -l html/php-components/select-media.php`
- `php -l html/php-components/base-page-components.php`
- `composer validate --strict` *(fails: description required, lock file out of date)*

------
https://chatgpt.com/codex/tasks/task_b_68a656a80efc8333b038218c87a54394