### PR TITLE
Use custom prompt when generating images

### DIFF
--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -215,14 +215,18 @@ function GeneratePromptImage(prompt)
     const finalPrompt = promptTemplates[template]
         ? promptTemplates[template](description, scenery, faction)
         : description;
+    const promptEl = document.getElementById('imagePrompt');
     const sizeEl = document.getElementById('imageSize');
     const modelEl = document.getElementById('imageModel');
     const sessionToken = "<?php echo $_SESSION["sessionToken"]; ?>";
 
     const formData = new URLSearchParams();
-    const resolvedPrompt = (typeof prompt === 'string' && prompt.length > 0)
-        ? prompt
-        : finalPrompt;
+    const resolvedPrompt =
+        (typeof prompt === 'string' && prompt.length > 0)
+            ? prompt
+            : (promptEl && promptEl.value.trim()
+                ? promptEl.value.trim()
+                : finalPrompt);
     formData.append('prompt', resolvedPrompt);
     if (directoryEl) { formData.append('directory', directoryEl.value); }
     if (nameEl) { formData.append('name', nameEl.value); }


### PR DESCRIPTION
## Summary
- Allow GenerateImageFromPrompt to use text from #imagePrompt when no prompt argument is given
- Default to user-entered text or template output when crafting resolved prompt

## Testing
- `npm test` *(fails: could not find package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68a65ff5382483339d37794242ba8d7b