### PR TITLE
Refine lich card art prompt template

### DIFF
--- a/html/php-components/select-media.php
+++ b/html/php-components/select-media.php
@@ -40,13 +40,9 @@ import { initPixelEditor, LAYER_DEFAULTS } from '<?= Version::urlBetaPrefix(); ?
 
 const promptTemplates = {
   "lich card art": (desc, scenery, faction) =>
-  `Extremely detailed fantasy pixel art in the style of high-end 1990s arcade games (SNK, Capcom).
-   Crisp, clean pixel edges with dense detailing and visible dithering for shading.
-   Heavy dramatic lighting with deep shadows and bright highlights for epic contrast.
-   Foreground, midground, and background filled with intricate elements for depth.
-   Vivid, saturated focal colors, muted background tones.
-   Dynamic, cinematic scene set in ${scenery}.
-   Featuring ${faction}. No painterly or realistic textures. ${desc}`
+  `High-detail retro pixel art card in 1990s arcade style (SNK, Capcom).
+   Sharp pixels, purposeful dithering, dramatic contrast.
+   Layered scene set in ${scenery}, featuring ${faction}. ${desc}`
 };
 
 


### PR DESCRIPTION
## Summary
- simplify lich card art prompt for higher-signal pixel art generations

## Testing
- `php -l html/php-components/select-media.php`
- `node` template invocation for placeholder substitution
- `composer install --no-progress --no-interaction` *(fails: Required package "openai-php/client" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_b_68a652a73fd08333af500f66c68e7143