### PR TITLE
Add RankedMatchCalculator unit tests

### DIFF
--- a/html/Kickback/Backend/Services/RankedMatchCalculator.php
+++ b/html/Kickback/Backend/Services/RankedMatchCalculator.php
@@ -102,4 +102,60 @@ class RankedMatchCalculator
     {
         return 1 / (1 + pow(10, ($ratingB - $ratingA) / 400));
     }
+
+    public static function unittests() : void
+    {
+        $class_fqn = self::class;
+        echo("Running `$class_fqn::unittests()`\n");
+
+        $calc = new self();
+
+        // 1v1
+        $teams = [
+            ['players' => [1], 'rank' => 1],
+            ['players' => [2], 'rank' => 2],
+        ];
+        $ratings = [];
+        $result = $calc->calculate($teams, $ratings);
+        assert($result === [1 => 1515, 2 => 1485]);
+
+        // 1v1v1
+        $teams = [
+            ['players' => [1], 'rank' => 1],
+            ['players' => [2], 'rank' => 2],
+            ['players' => [3], 'rank' => 3],
+        ];
+        $result = $calc->calculate($teams, []);
+        assert($result === [1 => 1529, 2 => 1485, 3 => 1486]);
+
+        // 1v2v3
+        $teams = [
+            ['players' => [1], 'rank' => 1],
+            ['players' => [2, 3], 'rank' => 2],
+            ['players' => [4, 5, 6], 'rank' => 3],
+        ];
+        $result = $calc->calculate($teams, []);
+        assert($result === [1 => 1529, 2 => 1485, 3 => 1485, 4 => 1486, 5 => 1486, 6 => 1486]);
+
+        // 2v2v4
+        $teams = [
+            ['players' => [1, 2], 'rank' => 1],
+            ['players' => [3, 4], 'rank' => 2],
+            ['players' => [5, 6, 7, 8], 'rank' => 3],
+        ];
+        $result = $calc->calculate($teams, []);
+        assert($result === [1 => 1529, 2 => 1529, 3 => 1485, 4 => 1485, 5 => 1486, 6 => 1486, 7 => 1486, 8 => 1486]);
+
+        // 1v1v1v1
+        $teams = [
+            ['players' => [1], 'rank' => 1],
+            ['players' => [2], 'rank' => 2],
+            ['players' => [3], 'rank' => 3],
+            ['players' => [4], 'rank' => 4],
+        ];
+        $result = $calc->calculate($teams, []);
+        assert($result === [1 => 1543, 2 => 1485, 3 => 1486, 4 => 1486]);
+
+        echo("  ... passed.\n\n");
+    }
 }

--- a/html/Kickback/Backend/UnittestEntryPoint.php
+++ b/html/Kickback/Backend/UnittestEntryPoint.php
@@ -20,6 +20,7 @@ class UnittestEntryPoint
         // * Alphabetic when packages are peers
 
         echo("===== Running all ".__NAMESPACE__." unittests =====\n\n");
+        \Kickback\Backend\Services\RankedMatchCalculator::unittests();
         \Kickback\Backend\Views\vDateTime::unittests();
         // TODO: Move unittests from `\Kickback\Common\Unittesting\Tests\vDateTime` to `vDateTime` class and call from here.
         // TODO: Move unittests from `\Kickback\Common\Unittesting\Tests\vDecimal` to `vDecimal` class and call from here.


### PR DESCRIPTION
## Summary
- add unit tests for RankedMatchCalculator covering multiple match scenarios
- include RankedMatchCalculator tests in backend test entrypoint

## Testing
- `php -d zend.assertions=1 scratch-pad/unittest.php` *(fails: AssertionError in Kickback\Common\Primitives\Meta::unittests())*
- `php -d zend.assertions=1 -r 'require "Kickback/init.php"; \Kickback\Backend\Services\RankedMatchCalculator::unittests();'`


------
https://chatgpt.com/codex/tasks/task_b_68a779fd124483339beeed7a3b183875