### PR TITLE
Add quest review rating trend chart

### DIFF
--- a/html/Kickback/Backend/Controllers/NotificationController.php
+++ b/html/Kickback/Backend/Controllers/NotificationController.php
@@ -129,10 +129,12 @@ class NotificationController
             $questId = (int)$row['quest_id'];
             $hostRating = (int)$row['host_rating'];
             $questRating = (int)$row['quest_rating'];
+            $endDate = $row['date'];
 
             if (!isset($questRatings[$questId])) {
                 $questRatings[$questId] = [
                     'questTitle' => $row['name'],
+                    'endDate' => $endDate,
                     'hostRatingSum' => $hostRating,
                     'questRatingSum' => $questRating,
                     'count' => 1,
@@ -141,6 +143,10 @@ class NotificationController
                 $questRatings[$questId]['hostRatingSum'] += $hostRating;
                 $questRatings[$questId]['questRatingSum'] += $questRating;
                 $questRatings[$questId]['count']++;
+                // In case the date wasn't set previously, ensure it's stored
+                if (!isset($questRatings[$questId]['endDate'])) {
+                    $questRatings[$questId]['endDate'] = $endDate;
+                }
             }
         }
 
@@ -148,6 +154,7 @@ class NotificationController
         foreach ($questRatings as $data) {
             $averages[] = [
                 'questTitle' => $data['questTitle'],
+                'endDate' => $data['endDate'],
                 'avgHostRating' => $data['hostRatingSum'] / $data['count'],
                 'avgQuestRating' => $data['questRatingSum'] / $data['count'],
             ];

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -29,9 +29,17 @@ $reviewsResp = NotificationController::queryQuestReviewsByHostAsResponse($accoun
 $questReviewAverages = $reviewsResp->success ? $reviewsResp->data : [];
 
 $totalHostedQuests = count($futureQuests) + count($pastQuests);
-$questTitles = array_column($questReviewAverages, 'questTitle');
 $avgHostRatings = array_map('floatval', array_column($questReviewAverages, 'avgHostRating'));
 $avgQuestRatings = array_map('floatval', array_column($questReviewAverages, 'avgQuestRating'));
+
+// Build rating trend arrays sorted by quest end date
+$sortedReviews = $questReviewAverages;
+usort($sortedReviews, function ($a, $b) {
+    return strcmp($a['endDate'] ?? '', $b['endDate'] ?? '');
+});
+$ratingDates = array_column($sortedReviews, 'endDate');
+$hostRatingTrend = array_map('floatval', array_column($sortedReviews, 'avgHostRating'));
+$questRatingTrend = array_map('floatval', array_column($sortedReviews, 'avgQuestRating'));
 
 $participantDates = [];
 $participantCounts = [];
@@ -198,9 +206,9 @@ function renderStarRating(int $rating): string
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js"></script>
 <script>
-const questTitles = <?= json_encode($questTitles); ?>;
-const avgHostRatings = <?= json_encode($avgHostRatings); ?>;
-const avgQuestRatings = <?= json_encode($avgQuestRatings); ?>;
+const ratingDates = <?= json_encode($ratingDates); ?>;
+const hostRatingTrend = <?= json_encode($hostRatingTrend); ?>;
+const questRatingTrend = <?= json_encode($questRatingTrend); ?>;
 const participantDates = <?= json_encode($participantDates); ?>;
 const participantCounts = <?= json_encode($participantCounts); ?>;
 const participantQuestTitles = <?= json_encode($participantQuestTitles); ?>;
@@ -213,24 +221,38 @@ $(document).ready(function () {
 
     var reviewCtx = document.getElementById('reviewChart').getContext('2d');
     new Chart(reviewCtx, {
-        type: 'bar',
+        type: 'line',
         data: {
-            labels: questTitles,
+            labels: ratingDates,
             datasets: [
                 {
                     label: 'Avg Host Rating',
-                    data: avgHostRatings,
-                    backgroundColor: 'rgba(75, 192, 192, 0.6)'
+                    data: hostRatingTrend,
+                    fill: false,
+                    borderColor: 'rgba(75, 192, 192, 1)',
+                    tension: 0.1
                 },
                 {
                     label: 'Avg Quest Rating',
-                    data: avgQuestRatings,
-                    backgroundColor: 'rgba(153, 102, 255, 0.6)'
+                    data: questRatingTrend,
+                    fill: false,
+                    borderColor: 'rgba(153, 102, 255, 1)',
+                    tension: 0.1
                 }
             ]
         },
         options: {
             scales: {
+                xAxes: [{
+                    type: 'time',
+                    time: {
+                        parser: 'YYYY-MM-DD',
+                        unit: 'day',
+                        displayFormats: {
+                            day: 'MMM D'
+                        }
+                    }
+                }],
                 yAxes: [{
                     ticks: {
                         beginAtZero: true,


### PR DESCRIPTION
## Summary
- Track quest review averages with end dates
- Visualize host vs quest rating trends over time with Chart.js line chart

## Testing
- `php -l html/Kickback/Backend/Controllers/NotificationController.php`
- `php -l html/quest-giver-dashboard.php`
- `composer exec phpstan analyse` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c4dca9f6808333b4b3ed4a9b3d0753