### PR TITLE
Add participant review details to quest dashboard

### DIFF
--- a/html/api/v1/engine/quest/reviews.php
+++ b/html/api/v1/engine/quest/reviews.php
@@ -1,0 +1,23 @@
+<?php
+require_once(__DIR__ . "/../../engine/engine.php");
+
+use Kickback\Backend\Controllers\NotificationController;
+use Kickback\Backend\Views\vQuest;
+use Kickback\Backend\Models\Response;
+
+OnlyPOST();
+
+$containsFieldsResp = POSTContainsFields("questId");
+if (!$containsFieldsResp->success) {
+    return $containsFieldsResp;
+}
+
+$questId = Validate($_POST["questId"]);
+if (is_string($questId) && !ctype_digit($questId)) {
+    return new Response(false, "'questId' parameter must be integer, but was not.", null);
+}
+
+$quest = new vQuest('', intval($questId));
+
+return NotificationController::queryQuestReviewDetailsAsResponse($quest);
+?>

--- a/html/api/v1/quest/reviews.php
+++ b/html/api/v1/quest/reviews.php
@@ -1,0 +1,5 @@
+<?php
+$resp = require(__DIR__ . '/../engine/quest/reviews.php');
+
+$resp->Return();
+?>


### PR DESCRIPTION
## Summary
- Show quest date and review details in quest giver dashboard
- Add API endpoint to fetch participant review statuses
- Include modal to display individual participant comments and ratings

## Testing
- `php -l html/Kickback/Backend/Controllers/NotificationController.php`
- `php -l html/api/v1/engine/quest/reviews.php`
- `php -l html/api/v1/quest/reviews.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c4e1fe6e548333b659a4a17dfb30de