### PR TITLE
Secure quest review API and fix dashboard modal

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -257,6 +257,8 @@ function renderStarRatingJs(rating) {
 }
 
 $(document).ready(function () {
+    const sessionToken = "<?= $_SESSION['sessionToken']; ?>";
+
     $('#datatable-reviews').DataTable({
         pageLength: 5,
         lengthChange: true,
@@ -270,7 +272,7 @@ $(document).ready(function () {
         $('#reviewModalBody').html('<div class="text-center p-3"><i class="fa fa-spinner fa-spin"></i></div>');
         $('#reviewModal').modal('show');
 
-        $.post('/api/v1/quest/reviews.php', { questId: questId }, function (resp) {
+        $.post('/api/v1/quest/reviews.php', { questId: questId, sessionToken: sessionToken }, function (resp) {
             if (resp.success) {
                 const list = $('<div class="list-group"></div>');
                 resp.data.forEach(function (r) {
@@ -292,7 +294,7 @@ $(document).ready(function () {
             } else {
                 $('#reviewModalBody').html('<div class="text-danger">' + resp.message + '</div>');
             }
-        });
+        }, 'json');
     });
 
     var reviewCtx = document.getElementById('reviewChart').getContext('2d');


### PR DESCRIPTION
## Summary
- Fix quest giver dashboard review modal by parsing JSON and passing session token
- Restrict quest review API to authenticated quest owners

## Testing
- `php -l html/api/v1/engine/quest/reviews.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c4e705e7a48333b504982478b562bb