### PR TITLE
Filter quest reviews to participants and flag comment presence

### DIFF
--- a/html/Kickback/Backend/Controllers/QuestController.php
+++ b/html/Kickback/Backend/Controllers/QuestController.php
@@ -1194,6 +1194,8 @@ class QuestController
 
         $questApplicant->seed = $row["seed"];
         $questApplicant->rank = (int)($row["rank"] ?? -1);
+        $questApplicant->accepted = boolval($row["accepted"] ?? false);
+        $questApplicant->participated = boolval($row["participated"] ?? false);
         return $questApplicant;
     }
 

--- a/html/Kickback/Backend/Views/vQuestApplicant.php
+++ b/html/Kickback/Backend/Views/vQuestApplicant.php
@@ -12,6 +12,8 @@ class vQuestApplicant extends vRecordId
     public int $seed;
     public int $rank;
     public string $displayName;
+    public bool $accepted;
+    public bool $participated;
 
     function __construct(string $ctime = '', int $crand = -1)
     {

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -168,6 +168,9 @@ function renderStarRating(int $rating): string
                                                 <?= number_format($qr['avgQuestRating'], 2); ?>
                                             </td>
                                             <td>
+                                                <?php if (!empty($qr['hasComments'])) { ?>
+                                                    <i class="fa-solid fa-comment text-info me-1" title="Has comments"></i>
+                                                <?php } ?>
                                                 <button class="btn btn-sm btn-primary view-reviews-btn" data-quest-id="<?= $qr['questId']; ?>" data-quest-title="<?= htmlspecialchars($qr['questTitle']); ?>">View</button>
                                             </td>
                                         </tr>


### PR DESCRIPTION
## Summary
- Filter quest review details to show only participating accounts, excluding hosts
- Highlight quests with review comments in dashboard table

## Testing
- `composer install` (fails: requires GitHub token)
- `./html/vendor/composer/bin/phpstan analyse -c meta/phpstan.neon` (fails: file not found)
- `php -l html/Kickback/Backend/Views/vQuestApplicant.php`
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/Kickback/Backend/Controllers/NotificationController.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c4eb03af1c8333838a928e373234e5