### PR TITLE
fix: limit date tag width in quest reviews table

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -163,7 +163,7 @@ function renderStarRating(int $rating): string
                                             </td>
                                             <?php $qd = new vDateTime($qr->questEndDate); ?>
                                             <td data-order="<?= htmlspecialchars($qd->dbValue); ?>">
-                                                <div class="date" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="<?= htmlspecialchars($qd->formattedDetailed); ?> UTC" data-datetime-utc="<?= htmlspecialchars($qd->valueString); ?>" data-db-value="<?= htmlspecialchars($qd->dbValue); ?>"><?= htmlspecialchars($qd->formattedBasic); ?></div>
+                                                <span class="date" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="<?= htmlspecialchars($qd->formattedDetailed); ?> UTC" data-datetime-utc="<?= htmlspecialchars($qd->valueString); ?>" data-db-value="<?= htmlspecialchars($qd->dbValue); ?>"><?= htmlspecialchars($qd->formattedBasic); ?></span>
                                             </td>
                                             <td data-order="<?= $qr->avgHostRating; ?>" class="align-middle">
                                                 <?= renderStarRating((int)round($qr->avgHostRating)); ?><span class="ms-1"><?= number_format($qr->avgHostRating, 2); ?></span>


### PR DESCRIPTION
## Summary
- ensure quest review date tag only wraps text, not full table cell

## Testing
- `php -l html/quest-giver-dashboard.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68c574813eec833390ef9d101ee33f65