### PR TITLE
Ensure quest dashboard uses actual participants

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -48,7 +48,13 @@ usort($allQuests, fn($a, $b) => strcmp(
 ));
 foreach ($allQuests as $quest) {
     $participantsResp = QuestController::queryQuestApplicantsAsResponse($quest);
-    $participants = $participantsResp->success ? $participantsResp->data : [];
+    $participants = [];
+    if ($participantsResp->success) {
+        $participants = array_filter(
+            $participantsResp->data,
+            fn($app) => $app->participated
+        );
+    }
     $count = count($participants);
     $participantCounts[] = $count;
     $participantQuestTitles[] = $quest->title;


### PR DESCRIPTION
## Summary
- filter quest giver dashboard stats to participants who actually attended

## Testing
- `sh meta/phpstan.sh` *(fails: Could not open input file: meta/../html/vendor/composer/phpstan/phpstan/phpstan)*
- `composer install` *(fails: CONNECT tunnel failed, response 403 and GitHub credentials required)*

------
https://chatgpt.com/codex/tasks/task_b_68c5834832788333a686efde82f7abf2