### PR TITLE
Allow passing applicants to quest review details

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -79,7 +79,8 @@ foreach ($allQuests as $quest) {
 $totalUniqueParticipants = count($uniqueParticipants);
 
 foreach ($pastQuests as $quest) {
-    $reviewDetailsResp = QuestController::queryQuestReviewDetailsAsResponse($quest);
+    $applicants = $applicantsByQuest[$quest->crand] ?? null;
+    $reviewDetailsResp = QuestController::queryQuestReviewDetailsAsResponse($quest, $applicants);
     if ($reviewDetailsResp->success) {
         foreach ($reviewDetailsResp->data as $detail) {
             $id = $detail->accountId;


### PR DESCRIPTION
## Summary
- Support providing preloaded applicants to `queryQuestReviewDetailsAsResponse`
- Join applicants with reviews when none are supplied
- Reuse batched applicant data in quest giver dashboard

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/quest-giver-dashboard.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68c588d07ea08333af2398c3584fc287