### PR TITLE
Avoid N+1 quest review queries

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -78,18 +78,17 @@ foreach ($allQuests as $quest) {
 }
 $totalUniqueParticipants = count($uniqueParticipants);
 
+$pastQuestIds = array_map(fn($q) => $q->crand, $pastQuests);
+$reviewDetailsByQuest = QuestController::queryQuestReviewDetailsForQuests($pastQuestIds);
+
 foreach ($pastQuests as $quest) {
-    $applicants = $applicantsByQuest[$quest->crand] ?? null;
-    $reviewDetailsResp = QuestController::queryQuestReviewDetailsAsResponse($quest, $applicants);
-    if ($reviewDetailsResp->success) {
-        foreach ($reviewDetailsResp->data as $detail) {
-            $id = $detail->accountId;
-            if ($id === $account->crand || is_null($detail->hostRating)) {
-                continue;
-            }
-            $participantRatingSums[$id] = ($participantRatingSums[$id] ?? 0) + $detail->hostRating;
-            $participantRatingCounts[$id] = ($participantRatingCounts[$id] ?? 0) + 1;
+    foreach ($reviewDetailsByQuest[$quest->crand] ?? [] as $detail) {
+        $id = $detail->accountId;
+        if ($id === $account->crand || is_null($detail->hostRating)) {
+            continue;
         }
+        $participantRatingSums[$id] = ($participantRatingSums[$id] ?? 0) + $detail->hostRating;
+        $participantRatingCounts[$id] = ($participantRatingCounts[$id] ?? 0) + 1;
     }
 }
 $participantAvgRatings = [];


### PR DESCRIPTION
## Summary
- add `queryQuestReviewDetailsForQuests` to load quest review details for many quests at once
- mark single-quest review query deprecated
- refactor quest-giver dashboard to preload review details map

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/quest-giver-dashboard.php`
- `./meta/phpstan.sh` *(fails: Could not open input file: ./meta/../html/vendor/composer/phpstan/phpstan/phpstan)*

------
https://chatgpt.com/codex/tasks/task_b_68c58ebe2ac48333830011882cdbdadc