### PR TITLE
Add suggestions tab to quest giver dashboard

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -220,6 +220,7 @@ function renderStarRating(int $rating): string
                     <button class="nav-link" id="nav-past-tab" data-bs-toggle="tab" data-bs-target="#nav-past" type="button" role="tab" aria-controls="nav-past" aria-selected="false"><i class="fa-solid fa-clock-rotate-left"></i></button>
                     <button class="nav-link" id="nav-reviews-tab" data-bs-toggle="tab" data-bs-target="#nav-reviews" type="button" role="tab" aria-controls="nav-reviews" aria-selected="false"><i class="fa-solid fa-star"></i></button>
                     <button class="nav-link" id="nav-graphs-tab" data-bs-toggle="tab" data-bs-target="#nav-graphs" type="button" role="tab" aria-controls="nav-graphs" aria-selected="false"><i class="fa-solid fa-chart-line"></i></button>
+                    <button class="nav-link" id="nav-suggestions-tab" data-bs-toggle="tab" data-bs-target="#nav-suggestions" type="button" role="tab" aria-controls="nav-suggestions" aria-selected="false"><i class="fa-solid fa-lightbulb"></i></button>
                     <button class="nav-link" id="nav-top-tab" data-bs-toggle="tab" data-bs-target="#nav-top" type="button" role="tab" aria-controls="nav-top" aria-selected="false"><i class="fa-solid fa-trophy"></i></button>
                 </div>
             </nav>
@@ -329,6 +330,10 @@ function renderStarRating(int $rating): string
                             </div>
                         </div>
                     </div>
+                </div>
+                <div class="tab-pane fade" id="nav-suggestions" role="tabpanel" aria-labelledby="nav-suggestions-tab" tabindex="0">
+                    <div class="display-6 tab-pane-title">Suggestions</div>
+                    <!-- Recommendation widgets go here -->
                 </div>
                 <div class="tab-pane fade" id="nav-top" role="tabpanel" aria-labelledby="nav-top-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Top Quests & Participants</div>


### PR DESCRIPTION
## Summary
- add Suggestions tab and placeholder pane to quest giver dashboard for recommendation widgets

## Testing
- `php -l html/quest-giver-dashboard.php`
- `composer validate --no-check-all --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_b_68c591620fb08333889b660924c7c9fa