### PR TITLE
Add quest participation calendar to dashboard

### DIFF
--- a/html/api/v1/engine/quest/participationByDate.php
+++ b/html/api/v1/engine/quest/participationByDate.php
@@ -1,0 +1,27 @@
+<?php
+require_once(__DIR__ . "/../../engine/engine.php");
+
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Controllers\QuestController;
+use Kickback\Backend\Config\ServiceCredentials;
+use Kickback\Backend\Views\vRecordId;
+use Kickback\Backend\Models\Response;
+
+OnlyPOST();
+
+$contains = POSTContainsFields("sessionToken");
+if (!$contains->success) {
+    return $contains;
+}
+
+$sessionToken = Validate($_POST["sessionToken"]);
+
+$kk_service_key = ServiceCredentials::get("kk_service_key");
+$loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+if (!$loginResp->success) {
+    return $loginResp;
+}
+$account = $loginResp->data;
+
+return QuestController::getParticipationByDate(new vRecordId('', $account->crand));
+?>

--- a/html/api/v1/quest/participationByDate.php
+++ b/html/api/v1/quest/participationByDate.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__ . '/../engine/quest/participationByDate.php');
+$resp->Return();
+?>


### PR DESCRIPTION
## Summary
- add `QuestController::getParticipationByDate` for quest participation counts
- expose API endpoint returning participation by date
- render schedule planning calendar in quest giver dashboard using participation data

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/api/v1/engine/quest/participationByDate.php`
- `php -l html/api/v1/quest/participationByDate.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5d8b1e0608333a2a0b40421779a54