### PR TITLE
Add weekday participation analytics

### DIFF
--- a/html/api/v1/engine/quest/participationAveragesByWeekday.php
+++ b/html/api/v1/engine/quest/participationAveragesByWeekday.php
@@ -1,0 +1,27 @@
+<?php
+require_once(__DIR__ . "/../../engine/engine.php");
+
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Controllers\QuestController;
+use Kickback\Backend\Config\ServiceCredentials;
+use Kickback\Backend\Views\vRecordId;
+use Kickback\Backend\Models\Response;
+
+OnlyPOST();
+
+$contains = POSTContainsFields("sessionToken");
+if (!$contains->success) {
+    return $contains;
+}
+
+$sessionToken = Validate($_POST["sessionToken"]);
+
+$kk_service_key = ServiceCredentials::get("kk_service_key");
+$loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+if (!$loginResp->success) {
+    return $loginResp;
+}
+$account = $loginResp->data;
+
+return QuestController::getParticipationAveragesByWeekday(new vRecordId('', $account->crand));
+?>

--- a/html/api/v1/quest/participationAveragesByWeekday.php
+++ b/html/api/v1/quest/participationAveragesByWeekday.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__ . '/../engine/quest/participationAveragesByWeekday.php');
+$resp->Return();
+?>


### PR DESCRIPTION
## Summary
- compute average quest participation by weekday on backend
- expose weekday averages via new API endpoint
- visualize weekday averages on Quest Giver dashboard schedule with Chart.js

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/api/v1/engine/quest/participationAveragesByWeekday.php`
- `php -l html/api/v1/quest/participationAveragesByWeekday.php`
- `php -l html/quest-giver-dashboard.php`
- `./meta/phpstan.sh` *(fails: Could not open input file: ./meta/../html/vendor/composer/phpstan/phpstan/phpstan)*

------
https://chatgpt.com/codex/tasks/task_b_68c5da468340833385f8817438f90c3f