### PR TITLE
Add scheduling suggestions and API endpoint

### DIFF
--- a/html/api/v1/engine/schedule/suggestedDates.php
+++ b/html/api/v1/engine/schedule/suggestedDates.php
@@ -1,0 +1,15 @@
+<?php
+require_once(__DIR__ . '/../engine.php');
+
+use Kickback\Backend\Controllers\ScheduleController;
+use Kickback\Backend\Models\Response;
+
+OnlyGET();
+
+$month = isset($_GET['month']) ? intval($_GET['month']) : intval(date('m'));
+$year  = isset($_GET['year']) ? intval($_GET['year']) : intval(date('Y'));
+
+$suggestions = ScheduleController::getSuggestedDates($month, $year);
+
+return new Response(true, 'Suggested dates generated', $suggestions);
+?>

--- a/html/api/v1/schedule/suggestedDates.php
+++ b/html/api/v1/schedule/suggestedDates.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__ . '/../engine/schedule/suggestedDates.php');
+$resp->Return();
+?>

--- a/html/schedule.php
+++ b/html/schedule.php
@@ -34,10 +34,17 @@ $events = ScheduleController::getCalendarEvents($month, $year);
                 require("php-components/base-page-breadcrumbs.php"); 
                 ?>
                 <div class="card card-body bg-primary table-responsive px-0">
-                  <h2 class="text-white"><span id="calendarPage"></span><button id="next" class="btn btn-secondary float-end bg-ranked-1" onclick="NextMonth();">Next</button><button id="prev" class="btn btn-secondary float-end me-2 bg-ranked-1" onclick="PreviousMonth();">Previous</button></h2> 
+                  <h2 class="text-white"><span id="calendarPage"></span><button id="next" class="btn btn-secondary float-end bg-ranked-1" onclick="NextMonth();">Next</button><button id="prev" class="btn btn-secondary float-end me-2 bg-ranked-1" onclick="PreviousMonth();">Previous</button></h2>
                   <table id="calendar" class="calendar table table-sm table-bordered">
                       <!-- Calendar will be generated here -->
                   </table>
+                </div>
+
+                <div class="card mt-3">
+                  <div class="card-header">Suggested Dates</div>
+                  <div class="card-body" id="suggested-dates">
+                    Loading...
+                  </div>
                 </div>
 
             </div>
@@ -54,7 +61,7 @@ $events = ScheduleController::getCalendarEvents($month, $year);
         // Convert the PHP array to JSON so JavaScript can use it
         var events = <?php echo json_encode($events); ?>;
     </script>
-    <script>
+<script>
     var month = <?php echo $month; ?>; // July
     var year = <?php echo $year; ?>;
 
@@ -96,6 +103,7 @@ $events = ScheduleController::getCalendarEvents($month, $year);
         month++;
       }
       generateCalendar(month, year);
+      loadSuggestedDates();
     }
 
     function PreviousMonth()
@@ -107,9 +115,33 @@ $events = ScheduleController::getCalendarEvents($month, $year);
         month--;
       }
       generateCalendar(month, year);
+      loadSuggestedDates();
+    }
+
+    function loadSuggestedDates() {
+      fetch(`/api/v1/schedule/suggestedDates.php?month=${month+1}&year=${year}`)
+        .then(response => response.json())
+        .then(data => {
+          var container = document.getElementById('suggested-dates');
+          if (data.success && data.data.length > 0) {
+            container.innerHTML = '';
+            data.data.forEach(item => {
+              var p = document.createElement('p');
+              p.textContent = `${item.date} - ${item.reason}`;
+              container.appendChild(p);
+            });
+          } else {
+            container.textContent = 'No suggestions available';
+          }
+        })
+        .catch(() => {
+          var container = document.getElementById('suggested-dates');
+          container.textContent = 'Failed to load suggestions';
+        });
     }
 
     generateCalendar(month, year);
+    loadSuggestedDates();
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- project high-engagement dates from historical patterns and current events
- expose suggested schedule dates via new API endpoint
- show "Suggested Dates" panel in scheduling tab

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -l html/api/v1/engine/schedule/suggestedDates.php`
- `php -l html/api/v1/schedule/suggestedDates.php`
- `php -l html/schedule.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5dbe5d2a88333aece7be7d1cd157c