### PR TITLE
Enhance schedule planning with event conflicts

### DIFF
--- a/html/api/v1/engine/schedule/events.php
+++ b/html/api/v1/engine/schedule/events.php
@@ -1,0 +1,29 @@
+<?php
+require_once(__DIR__ . '/../engine.php');
+
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Controllers\ScheduleController;
+use Kickback\Backend\Config\ServiceCredentials;
+use Kickback\Backend\Models\Response;
+
+OnlyGET();
+
+$month = isset($_GET['month']) ? intval($_GET['month']) : intval(date('m'));
+$year  = isset($_GET['year']) ? intval($_GET['year']) : intval(date('Y'));
+
+$questGiverId = null;
+if (isset($_GET['sessionToken'])) {
+    $sessionToken = Validate($_GET['sessionToken']);
+    $kk_service_key = ServiceCredentials::get('kk_service_key');
+    $loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+    if (!$loginResp->success) {
+        return $loginResp;
+    }
+    $account = $loginResp->data;
+    $questGiverId = $account->crand;
+}
+
+$events = ScheduleController::getCalendarEvents($month, $year, $questGiverId);
+
+return new Response(true, 'Calendar events loaded.', $events);
+?>

--- a/html/api/v1/schedule/events.php
+++ b/html/api/v1/schedule/events.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__ . '/../engine/schedule/events.php');
+$resp->Return();
+?>


### PR DESCRIPTION
## Summary
- extend calendar event retrieval to merge quest giver's own quests with global events
- add API endpoint to supply these calendar events via session token
- highlight conflicts and free days in quest giver dashboard with tooltips listing overlaps

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -l html/api/v1/engine/schedule/events.php`
- `php -l html/api/v1/schedule/events.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5dd12d70883338484754227340897