### PR TITLE
Add quest performance history API and calendar overlays

### DIFF
--- a/html/api/v1/engine/quest/history.php
+++ b/html/api/v1/engine/quest/history.php
@@ -1,0 +1,27 @@
+<?php
+require_once(__DIR__ . "/../../engine/engine.php");
+
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Controllers\QuestController;
+use Kickback\Backend\Config\ServiceCredentials;
+use Kickback\Backend\Views\vRecordId;
+use Kickback\Backend\Models\Response;
+
+OnlyPOST();
+
+$contains = POSTContainsFields("sessionToken");
+if (!$contains->success) {
+    return $contains;
+}
+
+$sessionToken = Validate($_POST["sessionToken"]);
+
+$kk_service_key = ServiceCredentials::get("kk_service_key");
+$loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+if (!$loginResp->success) {
+    return $loginResp;
+}
+$account = $loginResp->data;
+
+return QuestController::queryHostQuestHistoryAsResponse(new vRecordId('', $account->crand));
+?>

--- a/html/api/v1/quest/history.php
+++ b/html/api/v1/quest/history.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__ . '/../engine/quest/history.php');
+$resp->Return();
+?>


### PR DESCRIPTION
## Summary
- expose new quest history endpoint to return past quests with participation counts and average ratings
- aggregate past quest performance by date and weekday for logged-in hosts
- highlight high-performing days on schedule calendar with clickable star badges

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/api/v1/engine/quest/history.php`
- `php -l html/api/v1/quest/history.php`
- `php -l html/schedule.php`
- `bash meta/phpstan.sh` *(fails: Could not open input file: meta/../html/vendor/composer/phpstan/phpstan/phpstan)*


------
https://chatgpt.com/codex/tasks/task_b_68c5de4844cc8333a2c1ae655882320d