### PR TITLE
Fix schedule events API and calendar retrieval

### DIFF
--- a/html/Kickback/Backend/Controllers/ScheduleController.php
+++ b/html/Kickback/Backend/Controllers/ScheduleController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kickback\Backend\Controllers;
 
+use Kickback\Services\Database;
 
 class ScheduleController
 {
@@ -29,8 +30,8 @@ class ScheduleController
     */
     public static function getCalendarEvents(int $month, int $year, ?int $questGiverId = null) : array
     {
-        // Use global connection
-        $db = $GLOBALS['conn'];
+        // Use dedicated database connection service
+        $db = Database::getConnection();
 
         // Retrieve global calendar events for the specified month and year
         $query = "SELECT * FROM calendar_events WHERE MONTH(start_date) = ? AND YEAR(start_date) = ?";
@@ -76,7 +77,7 @@ class ScheduleController
     */
     public static function getSuggestedDates(int $month, int $year, int $limit = 3) : array
     {
-        $db = $GLOBALS['conn'];
+        $db = Database::getConnection();
 
         // Historical engagement averages by day of week (1=Sunday .. 7=Saturday)
         $avgQuery = "SELECT DAYOFWEEK(start_date) AS dow, COUNT(*) AS cnt

--- a/html/api/v1/engine/schedule/events.php
+++ b/html/api/v1/engine/schedule/events.php
@@ -6,14 +6,14 @@ use Kickback\Backend\Controllers\ScheduleController;
 use Kickback\Backend\Config\ServiceCredentials;
 use Kickback\Backend\Models\Response;
 
-OnlyGET();
+OnlyPOST();
 
-$month = isset($_GET['month']) ? intval($_GET['month']) : intval(date('m'));
-$year  = isset($_GET['year']) ? intval($_GET['year']) : intval(date('Y'));
+$month = isset($_POST['month']) ? intval($_POST['month']) : intval(date('m'));
+$year  = isset($_POST['year']) ? intval($_POST['year']) : intval(date('Y'));
 
 $questGiverId = null;
-if (isset($_GET['sessionToken'])) {
-    $sessionToken = Validate($_GET['sessionToken']);
+if (isset($_POST['sessionToken'])) {
+    $sessionToken = Validate($_POST['sessionToken']);
     $kk_service_key = ServiceCredentials::get('kk_service_key');
     $loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
     if (!$loginResp->success) {

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1375,7 +1375,7 @@ $(document).ready(function () {
     }
 
     function loadCalendarEvents() {
-        $.get('/api/v1/schedule/events.php', { sessionToken: sessionToken, month: calMonth + 1, year: calYear }, function(resp) {
+        $.post('/api/v1/schedule/events.php', { sessionToken: sessionToken, month: calMonth + 1, year: calYear }, function(resp) {
             if (resp.success) {
                 eventConflicts = {};
                 resp.data.forEach(function(e) {


### PR DESCRIPTION
## Summary
- use Database::getConnection in ScheduleController instead of undefined global
- switch schedule events API to POST and read parameters from `$_POST`
- update quest-giver dashboard to POST when loading calendar events

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -l html/api/v1/engine/schedule/events.php`
- `php -l html/quest-giver-dashboard.php`
- `composer install` *(fails: curl error 56 / GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_b_68c5e0a5ccd88333b097631eea0516d6