### PR TITLE
Enhance quest giver schedule calendar

### DIFF
--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -1115,3 +1115,14 @@ animation: confetti-fast 1.25s linear 1 forwards;
     flex-shrink: 0; /* Prevent the actions from shrinking */
     margin-left: 1rem; /* Add some spacing between the details and the actions */
 }
+
+#scheduleCalendar td {
+    height: 120px;
+    vertical-align: top;
+    padding: 0.25rem;
+}
+
+.calendar-event-pill {
+    font-size: 0.75rem;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- show daily events as pills with time and participation tooltips
- count quest participants in schedule API
- polish calendar legend and styling, and fix false conflict warnings

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5f0dd58f08333b94857a09786721a