### PR TITLE
Show only time in calendar event pills

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1337,7 +1337,7 @@ $(document).ready(function () {
                 const time = start.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
                 const part = e.participants !== null ? ` - ${e.participants} participants` : '';
                 const pillTip = `${e.title}${part} @ ${time}`;
-                pills += `<div class=\"badge bg-primary rounded-pill text-truncate w-100 mb-1 calendar-event-pill\" data-bs-toggle=\"tooltip\" title=\"${pillTip.replace(/\"/g,'&quot;')}\">${time} ${e.title}</div>`;
+                pills += `<div class=\"badge bg-primary rounded-pill text-truncate w-100 mb-1 calendar-event-pill\" data-bs-toggle=\"tooltip\" title=\"${pillTip.replace(/\"/g,'&quot;')}\">${time}</div>`;
             });
             body += `<td class="${cls}" ${tooltip}><div class="fw-bold">${date.getDate()}</div>${pills}${(!events.length && count) ? `<small>${count} participants</small>` : ''}</td>`;
             if (date.getDay() === 6) { body += '</tr><tr>'; }


### PR DESCRIPTION
## Summary
- Trim calendar event pill text to show only time and keep title in tooltip

## Testing
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5f4ba00408333a2bf4f93aca574ca