### PR TITLE
Highlight current day in schedule calendar

### DIFF
--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -1122,6 +1122,10 @@ animation: confetti-fast 1.25s linear 1 forwards;
     padding: 0.25rem;
 }
 
+.calendar-today {
+    outline: 2px solid var(--bs-primary);
+}
+
 .calendar-event-pill {
     font-size: 0.75rem;
     cursor: pointer;

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1307,6 +1307,7 @@ $(document).ready(function () {
 
     function renderScheduleCalendar() {
         const first = new Date(calYear, calMonth, 1);
+        const today = new Date();
         const days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
         let header = '<thead><tr>' + days.map(d => `<th class="text-center">${d}</th>`).join('') + '</tr></thead>';
         const values = Object.values(participationCounts);
@@ -1319,6 +1320,7 @@ $(document).ready(function () {
             const count = participationCounts[dStr] || 0;
             const events = calendarEvents[dStr] || [];
             let cls = 'align-top';
+            if (date.toDateString() === today.toDateString()) { cls += ' calendar-today'; }
             if (count > 0 && max > 0) {
                 const ratio = count / max;
                 if (ratio > 0.66) { cls += ' bg-success text-white'; }


### PR DESCRIPTION
## Summary
- Highlight the current day in the schedule calendar by appending a `calendar-today` class when the iterated date equals today.
- Add a CSS rule for `.calendar-today` to visually emphasize the current day.

## Testing
- `php -l html/quest-giver-dashboard.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68c5f5c783f88333b57b000074a2dfdc