### PR TITLE
Refine calendar event pill layout

### DIFF
--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -1120,6 +1120,8 @@ animation: confetti-fast 1.25s linear 1 forwards;
     height: 120px;
     vertical-align: top;
     padding: 0.25rem;
+    display: flex;
+    flex-direction: column;
 }
 
 .calendar-today {
@@ -1129,4 +1131,6 @@ animation: confetti-fast 1.25s linear 1 forwards;
 .calendar-event-pill {
     font-size: 0.75rem;
     cursor: pointer;
+    display: inline-block;
+    padding: 0.125rem 0.25rem;
 }

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1339,7 +1339,7 @@ $(document).ready(function () {
                 const time = start.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
                 const part = e.participants !== null ? ` - ${e.participants} participants` : '';
                 const pillTip = `${e.title}${part} @ ${time}`;
-                pills += `<div class=\"badge bg-primary rounded-pill text-truncate w-100 mb-1 calendar-event-pill\" data-bs-toggle=\"tooltip\" title=\"${pillTip.replace(/\"/g,'&quot;')}\">${time}</div>`;
+                pills += `<div class=\"badge bg-primary rounded-pill text-truncate mb-1 calendar-event-pill\" data-bs-toggle=\"tooltip\" title=\"${pillTip.replace(/\"/g,'&quot;')}\">${time}</div>`;
             });
             body += `<td class="${cls}" ${tooltip}><div class="fw-bold">${date.getDate()}</div>${pills}${(!events.length && count) ? `<small>${count} participants</small>` : ''}</td>`;
             if (date.getDay() === 6) { body += '</tr><tr>'; }


### PR DESCRIPTION
## Summary
- Remove `w-100` utility from calendar event pills
- Style `.calendar-event-pill` with inline-block display and padding
- Arrange calendar day cells in a vertical flex column so multiple pills stack cleanly

## Testing
- `php -l html/quest-giver-dashboard.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_b_68c5f6764e3083338901c868854c0ed6