### PR TITLE
Improve suggested dates with personalized trends and conflicts

### DIFF
--- a/html/api/v1/engine/schedule/suggestedDates.php
+++ b/html/api/v1/engine/schedule/suggestedDates.php
@@ -2,14 +2,28 @@
 require_once(__DIR__ . '/../engine.php');
 
 use Kickback\Backend\Controllers\ScheduleController;
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Config\ServiceCredentials;
 use Kickback\Backend\Models\Response;
 
-OnlyGET();
+OnlyPOST();
 
-$month = isset($_GET['month']) ? intval($_GET['month']) : intval(date('m'));
-$year  = isset($_GET['year']) ? intval($_GET['year']) : intval(date('Y'));
+$month = isset($_POST['month']) ? intval($_POST['month']) : intval(date('m'));
+$year  = isset($_POST['year']) ? intval($_POST['year']) : intval(date('Y'));
 
-$suggestions = ScheduleController::getSuggestedDates($month, $year);
+$questGiverId = null;
+if (isset($_POST['sessionToken'])) {
+    $sessionToken = Validate($_POST['sessionToken']);
+    $kk_service_key = ServiceCredentials::get('kk_service_key');
+    $loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+    if (!$loginResp->success) {
+        return $loginResp;
+    }
+    $account = $loginResp->data;
+    $questGiverId = $account->crand;
+}
+
+$suggestions = ScheduleController::getSuggestedDates($month, $year, $questGiverId);
 
 return new Response(true, 'Suggested dates generated', $suggestions);
 ?>

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1414,13 +1414,14 @@ $(document).ready(function () {
     }
 
     function loadSuggestedDates() {
-        $.get('/api/v1/schedule/suggestedDates.php', { month: calMonth + 1, year: calYear }, function(resp) {
+        $.post('/api/v1/schedule/suggestedDates.php', { sessionToken: sessionToken, month: calMonth + 1, year: calYear }, function(resp) {
             const list = $('#suggestedDatesList');
             list.empty();
             if (resp && resp.success && resp.data.length) {
                 resp.data.forEach(function(item, idx) {
                     const prefix = idx === 0 ? '<strong>Next quest:</strong> ' : '';
-                    list.append(`<li>${prefix}${item.date} - ${item.reason}</li>`);
+                    const reason = item.reasons ? item.reasons.join('; ') : item.reason;
+                    list.append(`<li>${prefix}${item.date} - ${reason}</li>`);
                 });
             } else {
                 list.append('<li>No suggestions available</li>');

--- a/html/schedule.php
+++ b/html/schedule.php
@@ -124,7 +124,13 @@ $events = ScheduleController::getCalendarEvents($month, $year);
     }
 
     function loadSuggestedDates() {
-      fetch(`/api/v1/schedule/suggestedDates.php?month=${month+1}&year=${year}`)
+      var params = new URLSearchParams();
+      params.append('month', month + 1);
+      params.append('year', year);
+      if (typeof sessionToken !== 'undefined') {
+        params.append('sessionToken', sessionToken);
+      }
+      fetch('/api/v1/schedule/suggestedDates.php', { method: 'POST', body: params })
         .then(response => response.json())
         .then(data => {
           var container = document.getElementById('suggested-dates');
@@ -132,7 +138,8 @@ $events = ScheduleController::getCalendarEvents($month, $year);
             container.innerHTML = '';
             data.data.forEach(item => {
               var p = document.createElement('p');
-              p.textContent = `${item.date} - ${item.reason}`;
+              var reason = item.reasons ? item.reasons.join('; ') : item.reason;
+              p.textContent = `${item.date} - ${reason}`;
               container.appendChild(p);
             });
           } else {


### PR DESCRIPTION
## Summary
- Personalize date suggestions by factoring a quest giver's historic attendance and scanning other hosts' events to penalize conflicts.
- API endpoint `suggestedDates` now authenticates with a session token and forwards the host ID for personalized scoring.
- Front-end schedule views send session tokens and display richer reasons for suggested dates.

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -l html/api/v1/engine/schedule/suggestedDates.php`
- `php -l html/schedule.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5f97c22b083338d0f462a84ec7d36