### PR TITLE
Add hourly participation averages and dashboard chart

### DIFF
--- a/html/api/v1/engine/quest/participationAveragesByHour.php
+++ b/html/api/v1/engine/quest/participationAveragesByHour.php
@@ -1,0 +1,40 @@
+<?php
+require_once(__DIR__ . "/../../engine/engine.php");
+
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Controllers\QuestController;
+use Kickback\Backend\Config\ServiceCredentials;
+use Kickback\Backend\Views\vRecordId;
+use Kickback\Backend\Models\Response;
+
+OnlyPOST();
+
+$contains = POSTContainsFields("sessionToken");
+if (!$contains->success) {
+    return $contains;
+}
+
+$sessionToken = Validate($_POST["sessionToken"]);
+
+$kk_service_key = ServiceCredentials::get("kk_service_key");
+$loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+if (!$loginResp->success) {
+    return $loginResp;
+}
+$account = $loginResp->data;
+
+$personal = QuestController::getParticipationAveragesByHour(new vRecordId('', $account->crand));
+if (!$personal->success) {
+    return $personal;
+}
+
+$global = QuestController::getParticipationAveragesByHour();
+if (!$global->success) {
+    return $global;
+}
+
+return new Response(true, 'Average participation by hour loaded.', [
+    'personal' => $personal->data,
+    'global' => $global->data,
+]);
+?>

--- a/html/api/v1/quest/participationAveragesByHour.php
+++ b/html/api/v1/quest/participationAveragesByHour.php
@@ -1,0 +1,4 @@
+<?php
+$resp = require(__DIR__ . '/../engine/quest/participationAveragesByHour.php');
+$resp->Return();
+?>


### PR DESCRIPTION
## Summary
- add QuestController::getParticipationAveragesByHour and API endpoints for personal/global averages
- render "Average Participation by Hour" Chart.js card under scheduling tab with peak hour legend

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/api/v1/engine/quest/participationAveragesByHour.php`
- `php -l html/api/v1/quest/participationAveragesByHour.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5fa954e548333913e58e08ac05a78