### PR TITLE
Exclude raffle quests from schedule calendar

### DIFF
--- a/html/Kickback/Backend/Controllers/QuestController.php
+++ b/html/Kickback/Backend/Controllers/QuestController.php
@@ -1749,6 +1749,7 @@ class QuestController
             . "FROM quest_applicants qa "
             . "JOIN quest q ON qa.quest_id = q.Id "
             . "WHERE qa.participated = 1 AND (q.host_id = ? OR q.host_id_2 = ?) "
+            . "AND q.raffle_id IS NULL "
             . "GROUP BY DATE(q.end_date) ORDER BY day";
 
         $stmt = $conn->prepare($sql);

--- a/html/Kickback/Backend/Controllers/ScheduleController.php
+++ b/html/Kickback/Backend/Controllers/ScheduleController.php
@@ -64,7 +64,7 @@ class ScheduleController
                     . "FROM quest q "
                     . "JOIN account a ON a.Id = q.host_id "
                     . "LEFT JOIN quest_applicants qa ON qa.quest_id = q.Id AND qa.participated = 1 "
-                    . "WHERE MONTH(q.end_date) = ? AND YEAR(q.end_date) = ? "
+                    . "WHERE MONTH(q.end_date) = ? AND YEAR(q.end_date) = ? AND q.raffle_id IS NULL "
                     . "GROUP BY q.Id";
                 $stmt2 = mysqli_prepare($db, $questQuery);
                 if ($stmt2) {
@@ -89,6 +89,7 @@ class ScheduleController
                     . "LEFT JOIN quest_applicants qa ON qa.quest_id = q.Id AND qa.participated = 1 "
                     . "WHERE (q.host_id = ? OR q.host_id_2 = ?) "
                     . "AND MONTH(q.end_date) = ? AND YEAR(q.end_date) = ? "
+                    . "AND q.raffle_id IS NULL "
                     . "GROUP BY q.Id";
 
                 $stmt2 = mysqli_prepare($db, $questQuery);

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1334,10 +1334,9 @@ $(document).ready(function () {
                 else if (ratio > 0.33) { cls += ' bg-warning'; }
                 else { cls += ' bg-danger text-white'; }
             }
-            let tooltipLines = [];
-            if (count > 0) { tooltipLines.push(`Participants: ${count}`); }
+            let tooltipLines = [`Participants: ${count}`];
             if (events.length > 1) { tooltipLines.push('Conflicting events'); }
-            let tooltip = tooltipLines.length ? `data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="${tooltipLines.join('<br>').replace(/"/g, '&quot;')}"` : '';
+            let tooltip = `data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="${tooltipLines.join('<br>').replace(/"/g, '&quot;')}"`;
             if (events.length > 1) { cls += ' border border-danger border-2'; }
             else if (events.length === 1) { cls += ' border border-success border-2'; }
             let pills = '';


### PR DESCRIPTION
## Summary
- Filter raffle quests out of schedule calendar queries
- Always show daily participant counts on hover in schedule calendar

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5fcaabbe88333971f98c9c9e0cdb4