### PR TITLE
Exclude raffle quests from participation stats

### DIFF
--- a/html/Kickback/Backend/Controllers/QuestController.php
+++ b/html/Kickback/Backend/Controllers/QuestController.php
@@ -1782,7 +1782,7 @@ class QuestController
             . "SELECT DAYOFWEEK(q.end_date) AS weekday, COUNT(*) AS participants "
             . "FROM quest_applicants qa "
             . "JOIN quest q ON qa.quest_id = q.Id "
-            . "WHERE qa.participated = 1";
+            . "WHERE qa.participated = 1 AND q.raffle_id IS NULL";
 
         if ($hostId !== null) {
             $sql .= " AND (q.host_id = ? OR q.host_id_2 = ?)";
@@ -1826,7 +1826,7 @@ class QuestController
             . "SELECT HOUR(q.end_date) AS hour, COUNT(*) AS participants "
             . "FROM quest_applicants qa "
             . "JOIN quest q ON qa.quest_id = q.Id "
-            . "WHERE qa.participated = 1";
+            . "WHERE qa.participated = 1 AND q.raffle_id IS NULL";
 
         if ($hostId !== null) {
             $sql .= " AND (q.host_id = ? OR q.host_id_2 = ?)";


### PR DESCRIPTION
## Summary
- Exclude raffle quests from participation analytics by weekday and hour
- Ensure both global and host-specific stats ignore raffle entries

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php /tmp/test_queries.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68c5ff9aa95c833387475a103a9693cb