### PR TITLE
Exclude raffle quests from suggested date analysis

### DIFF
--- a/html/Kickback/Backend/Controllers/ScheduleController.php
+++ b/html/Kickback/Backend/Controllers/ScheduleController.php
@@ -144,7 +144,7 @@ class ScheduleController
                                    WHERE participated = 1
                                    GROUP BY quest_id
                                ) p ON p.quest_id = q.Id
-                               WHERE (q.host_id = ? OR q.host_id_2 = ?) AND q.end_date < CURDATE()
+                               WHERE (q.host_id = ? OR q.host_id_2 = ?) AND q.end_date < CURDATE() AND q.raffle_id IS NULL
                                GROUP BY dow";
             $stmt = mysqli_prepare($db, $personalQuery);
             if ($stmt) {


### PR DESCRIPTION
## Summary
- Exclude raffle quests when calculating personal participation averages in `ScheduleController::getSuggestedDates`

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -r "require 'html/Kickback/Services/Database.php'; require 'html/Kickback/Backend/Config/ServiceCredentials.php'; require 'html/Kickback/Backend/Controllers/ScheduleController.php'; Kickback\\Backend\\Controllers\\ScheduleController::getSuggestedDates(1,2024,null,3);"` *(fails: Could not find usable credential configuration ini file)*

------
https://chatgpt.com/codex/tasks/task_b_68c60068c5ec833380bfee12ad2e2f19