### PR TITLE
Enable global quest participation counts

### DIFF
--- a/html/api/v1/engine/quest/participationByDate.php
+++ b/html/api/v1/engine/quest/participationByDate.php
@@ -9,6 +9,14 @@ use Kickback\Backend\Models\Response;
 
 OnlyPOST();
 
+$includeAll = isset($_POST['includeAll']) && filter_var($_POST['includeAll'], FILTER_VALIDATE_BOOLEAN);
+$month = isset($_POST['month']) ? intval($_POST['month']) : null;
+$year = isset($_POST['year']) ? intval($_POST['year']) : null;
+
+if ($includeAll) {
+    return QuestController::getParticipationByDate(null, $month, $year);
+}
+
 $contains = POSTContainsFields("sessionToken");
 if (!$contains->success) {
     return $contains;
@@ -23,5 +31,5 @@ if (!$loginResp->success) {
 }
 $account = $loginResp->data;
 
-return QuestController::getParticipationByDate(new vRecordId('', $account->crand));
+return QuestController::getParticipationByDate(new vRecordId('', $account->crand), $month, $year);
 ?>


### PR DESCRIPTION
## Summary
- Allow `QuestController::getParticipationByDate` to accept an optional host ID plus month/year filters and aggregate counts globally when no host is provided.
- Extend `/api/v1/quest/participationByDate.php` to support `includeAll`, `month`, and `year` parameters for retrieving global statistics without authentication.
- Update quest giver dashboard to fetch global participation counts per month and shade the schedule calendar based on combined global and per-event totals.

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/api/v1/engine/quest/participationByDate.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c6024461b083339fa1be1fe559594b