### PR TITLE
Return reasons array for suggested quest dates

### DIFF
--- a/html/Kickback/Backend/Controllers/ScheduleController.php
+++ b/html/Kickback/Backend/Controllers/ScheduleController.php
@@ -113,7 +113,7 @@ class ScheduleController
     * Project future dates with high expected engagement.
     * Combines historic averages by weekday with current calendar events.
     *
-    * @return array<array{date: string, score: int, reason: string}>
+    * @return array<array{date: string, score: int, reasons: string[]}>
     */
     public static function getSuggestedDates(int $month, int $year, ?int $questGiverId = null, int $limit = 3) : array
     {
@@ -175,21 +175,21 @@ class ScheduleController
             $dateStr = sprintf('%04d-%02d-%02d', $year, $month, $day);
             $dow = intval(date('w', strtotime($dateStr))) + 1; // MySQL style
             $score = $averages[$dow] ?? 0;
-            $reason = [];
+            $reasons = [];
 
             if ($averages[$dow] > 0) {
-                $reason[] = 'Historically high engagement on ' . date('l', strtotime($dateStr));
+                $reasons[] = 'Historically high engagement on ' . date('l', strtotime($dateStr));
             } else {
-                $reason[] = 'No historical data for ' . date('l', strtotime($dateStr));
+                $reasons[] = 'No historical data for ' . date('l', strtotime($dateStr));
             }
 
             if ($questGiverId !== null) {
                 $personal = $personalAverages[$dow] ?? 0;
                 if ($personal > 0) {
                     $score += intval(round($personal));
-                    $reason[] = 'High personal turnout on ' . date('l', strtotime($dateStr));
+                    $reasons[] = 'High personal turnout on ' . date('l', strtotime($dateStr));
                 } else {
-                    $reason[] = 'No personal turnout data';
+                    $reasons[] = 'No personal turnout data';
                 }
             }
 
@@ -204,15 +204,15 @@ class ScheduleController
 
             if ($conflictCount > 0) {
                 $score -= 5 * $conflictCount;
-                $reason[] = 'Conflicts with ' . $conflictCount . ' other event' . ($conflictCount > 1 ? 's' : '');
+                $reasons[] = 'Conflicts with ' . $conflictCount . ' other event' . ($conflictCount > 1 ? 's' : '');
             } else {
-                $reason[] = 'No competing events';
+                $reasons[] = 'No competing events';
             }
 
             $suggestions[] = [
                 'date' => $dateStr,
                 'score' => $score,
-                'reason' => implode('; ', $reason)
+                'reasons' => $reasons
             ];
         }
 

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1054,7 +1054,7 @@ function renderStarRating(float $rating): string
                     </div>
                     <div class="card card-body mt-3">
                         <h5 class="mb-3">Suggested Next Quest Dates</h5>
-                        <ul id="suggestedDatesList" class="list-unstyled mb-0"></ul>
+                        <ul id="suggestedDatesList" class="list-group mb-0"></ul>
                     </div>
                     <div class="card card-body mt-3">
                         <h5 class="mb-3">Average Participation by Weekday</h5>
@@ -1483,12 +1483,34 @@ $(document).ready(function () {
             list.empty();
             if (resp && resp.success && resp.data.length) {
                 resp.data.forEach(function(item, idx) {
-                    const prefix = idx === 0 ? '<strong>Next quest:</strong> ' : '';
-                    const reason = item.reasons ? item.reasons.join('; ') : item.reason;
-                    list.append(`<li>${prefix}${item.date} - ${reason}</li>`);
+                    const dateObj = new Date(item.date);
+                    const formatted = dateObj.toLocaleDateString(undefined, {
+                        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
+                    });
+
+                    const li = $('<li class="list-group-item"></li>');
+                    const header = $('<div class="d-flex justify-content-between align-items-start"></div>');
+                    const left = $('<div></div>');
+                    if (idx === 0) {
+                        left.append('<span class="badge bg-success me-2">Next quest</span>');
+                    }
+                    left.append($('<strong></strong>').text(formatted));
+                    header.append(left);
+                    if (typeof item.score !== 'undefined') {
+                        header.append($('<span class="badge bg-primary"></span>').text(item.score));
+                    }
+                    li.append(header);
+                    if (Array.isArray(item.reasons) && item.reasons.length) {
+                        const ul = $('<ul class="mb-0 mt-2"></ul>');
+                        item.reasons.forEach(function(r) {
+                            ul.append($('<li></li>').text(r));
+                        });
+                        li.append(ul);
+                    }
+                    list.append(li);
                 });
             } else {
-                list.append('<li>No suggestions available</li>');
+                list.append('<li class="list-group-item">No suggestions available</li>');
             }
         }, 'json');
     }


### PR DESCRIPTION
## Summary
- Modify ScheduleController to return `reasons` arrays for suggested dates instead of a semicolon-separated string.
- Display suggested quest dates in dashboard with Bootstrap list groups, showing formatted dates, reasons as bullets, and score badges.

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c603769c208333a1c2a0d1e454d3d4