### PR TITLE
Fix scheduling suggestion date mismatch

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1494,7 +1494,8 @@ $(document).ready(function () {
             list.empty();
             if (resp && resp.success && resp.data.length) {
                 resp.data.forEach(function(item, idx) {
-                    const dateObj = new Date(item.date);
+                    const [y, m, d] = item.date.split('-').map(Number);
+                    const dateObj = new Date(y, m - 1, d);
                     const formatted = dateObj.toLocaleDateString(undefined, {
                         weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
                     });


### PR DESCRIPTION
## Summary
- Ensure suggested dates use local calendar date to match reasoning

## Testing
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c61a12a4848333a53bc530876b2fef