### PR TITLE
Filter suggested schedule dates to future

### DIFF
--- a/html/Kickback/Backend/Controllers/ScheduleController.php
+++ b/html/Kickback/Backend/Controllers/ScheduleController.php
@@ -171,8 +171,12 @@ class ScheduleController
 
         $suggestions = [];
         $daysInMonth = cal_days_in_month(CAL_GREGORIAN, $month, $year);
+        $today = date('Y-m-d');
         for ($day = 1; $day <= $daysInMonth; $day++) {
             $dateStr = sprintf('%04d-%02d-%02d', $year, $month, $day);
+            if ($dateStr < $today) {
+                continue;
+            }
             $dow = intval(date('w', strtotime($dateStr))) + 1; // MySQL style
             $score = $averages[$dow] ?? 0;
             $reasons = [];


### PR DESCRIPTION
## Summary
- Ensure suggested quest dates are in the future by skipping past days

## Testing
- `php -l html/Kickback/Backend/Controllers/ScheduleController.php`
- `php -l html/api/v1/engine/schedule/suggestedDates.php`


------
https://chatgpt.com/codex/tasks/task_b_68c6271497f08333849bcf46616165c8