### PR TITLE
feat: add review inbox for quest givers

### DIFF
--- a/html/api/v1/engine/quest/markReviewViewed.php
+++ b/html/api/v1/engine/quest/markReviewViewed.php
@@ -1,0 +1,32 @@
+<?php
+require_once(__DIR__ . '/../../engine/engine.php');
+
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Controllers\QuestController;
+use Kickback\Backend\Config\ServiceCredentials;
+use Kickback\Backend\Views\vRecordId;
+use Kickback\Backend\Models\Response;
+
+OnlyPOST();
+
+$contains = POSTContainsFields('applicantId', 'sessionToken');
+if (!$contains->success) {
+    return $contains;
+}
+
+$applicantId = Validate($_POST['applicantId']);
+$sessionToken = Validate($_POST['sessionToken']);
+
+$kk_service_key = ServiceCredentials::get('kk_service_key');
+$loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+if (!$loginResp->success) {
+    return $loginResp;
+}
+$account = $loginResp->data;
+
+$applicantId = new vRecordId('', (int)$applicantId);
+$accountId = new vRecordId('', $account->crand);
+
+return QuestController::markReviewAsViewed($applicantId, $accountId);
+?>
+

--- a/html/api/v1/engine/quest/reviewInbox.php
+++ b/html/api/v1/engine/quest/reviewInbox.php
@@ -1,0 +1,28 @@
+<?php
+require_once(__DIR__ . '/../../engine/engine.php');
+
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Controllers\QuestController;
+use Kickback\Backend\Config\ServiceCredentials;
+use Kickback\Backend\Views\vRecordId;
+use Kickback\Backend\Models\Response;
+
+OnlyPOST();
+
+$contains = POSTContainsFields('sessionToken');
+if (!$contains->success) {
+    return $contains;
+}
+
+$sessionToken = Validate($_POST['sessionToken']);
+
+$kk_service_key = ServiceCredentials::get('kk_service_key');
+$loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+if (!$loginResp->success) {
+    return $loginResp;
+}
+$account = $loginResp->data;
+
+return QuestController::queryReviewInbox(new vRecordId('', $account->crand));
+?>
+

--- a/html/api/v1/quest/markReviewViewed.php
+++ b/html/api/v1/quest/markReviewViewed.php
@@ -1,0 +1,6 @@
+<?php
+$resp = require(__DIR__ . '/../engine/quest/markReviewViewed.php');
+
+$resp->Return();
+?>
+

--- a/html/api/v1/quest/reviewInbox.php
+++ b/html/api/v1/quest/reviewInbox.php
@@ -1,0 +1,6 @@
+<?php
+$resp = require(__DIR__ . '/../engine/quest/reviewInbox.php');
+
+$resp->Return();
+?>
+


### PR DESCRIPTION
## Summary
- add Review Inbox tab to quest giver dashboard to view and mark reviews
- provide backend endpoints to fetch reviews and mark them viewed

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/quest-giver-dashboard.php`
- `php -l html/api/v1/quest/reviewInbox.php`
- `php -l html/api/v1/engine/quest/reviewInbox.php`
- `php -l html/api/v1/quest/markReviewViewed.php`
- `php -l html/api/v1/engine/quest/markReviewViewed.php`
- `./meta/phpstan.sh` *(fails: Could not open input file)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68c6e7c58d0483339906d1f1e32909c7