### PR TITLE
Fix review inbox query column reference

### DIFF
--- a/html/Kickback/Backend/Controllers/QuestController.php
+++ b/html/Kickback/Backend/Controllers/QuestController.php
@@ -1997,7 +1997,7 @@ class QuestController
         $conn = Database::getConnection();
         $host = $hostId->crand;
 
-        $sql = 'SELECT qa.Id, q.title, acc.Username AS username, qa.host_rating, qa.quest_rating, qa.feedback,
+        $sql = 'SELECT qa.Id, q.name AS title, acc.Username AS username, qa.host_rating, qa.quest_rating, qa.feedback,
                        IF(q.host_id = ?, qa.host_viewed, qa.host_2_viewed) AS viewed
                 FROM quest_applicants qa
                 JOIN quest q ON qa.quest_id = q.Id


### PR DESCRIPTION
## Summary
- fix review inbox SQL to select quest name instead of nonexistent `title` column

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`

------
https://chatgpt.com/codex/tasks/task_b_68c6ed17baf48333b99aba5ce28a4758