### PR TITLE
Show pending quester reviews in quest giver inbox

### DIFF
--- a/html/Kickback/Backend/Controllers/QuestController.php
+++ b/html/Kickback/Backend/Controllers/QuestController.php
@@ -1997,13 +1997,18 @@ class QuestController
         $conn = Database::getConnection();
         $host = $hostId->crand;
 
-        $sql = 'SELECT qa.Id, q.name AS title, acc.Username AS username, qa.host_rating, qa.quest_rating, qa.feedback,
-                       IF(q.host_id = ?, qa.host_viewed, qa.host_2_viewed) AS viewed
+        $sql = 'SELECT qa.Id,
+                       q.name AS title,
+                       acc.Username AS username,
+                       qa.host_rating,
+                       qa.quest_rating,
+                       qa.feedback,
+                       IF(q.host_id = ?, qa.host_viewed, qa.host_2_viewed) AS viewed,
+                       (qa.host_rating IS NOT NULL OR qa.quest_rating IS NOT NULL OR qa.feedback IS NOT NULL) AS has_review
                 FROM quest_applicants qa
                 JOIN quest q ON qa.quest_id = q.Id
                 JOIN v_account_info acc ON qa.account_id = acc.Id
                 WHERE qa.participated = 1
-                  AND (qa.host_rating IS NOT NULL OR qa.quest_rating IS NOT NULL OR qa.feedback IS NOT NULL)
                   AND (q.host_id = ? OR q.host_id_2 = ?)';
         $stmt = $conn->prepare($sql);
         if ($stmt === false) {
@@ -2027,6 +2032,7 @@ class QuestController
                 'questRating' => isset($row['quest_rating']) ? (int)$row['quest_rating'] : null,
                 'feedback' => $row['feedback'],
                 'viewed' => (int)$row['viewed'] === 1,
+                'hasReview' => (int)$row['has_review'] === 1,
             ];
         }
 

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1595,17 +1595,27 @@ $(document).ready(function () {
                     row.append($('<td></td>').text(r.questTitle));
                     const playerLink = $('<a></a>').attr('href', '/u/' + r.username).attr('target', '_blank').addClass('username').text(r.username);
                     row.append($('<td></td>').append(playerLink));
-                    row.append($('<td></td>').html(r.hostRating !== null ? renderStarRatingJs(r.hostRating) : ''));
-                    row.append($('<td></td>').html(r.questRating !== null ? renderStarRatingJs(r.questRating) : ''));
-                    row.append($('<td></td>').text(r.feedback || ''));
-                    row.append($('<td class="status"></td>').text(r.viewed ? 'Viewed' : 'Pending'));
-                    if (r.viewed) {
-                        row.append($('<td></td>'));
+
+                    if (r.hasReview) {
+                        row.append($('<td></td>').html(r.hostRating !== null ? renderStarRatingJs(r.hostRating) : ''));
+                        row.append($('<td></td>').html(r.questRating !== null ? renderStarRatingJs(r.questRating) : ''));
+                        row.append($('<td></td>').text(r.feedback || ''));
+                        row.append($('<td class="status"></td>').text(r.viewed ? 'Viewed' : 'Pending'));
+                        if (r.viewed) {
+                            row.append($('<td></td>'));
+                        } else {
+                            const btn = $('<button class="btn btn-sm btn-primary mark-viewed-btn">Mark Viewed</button>');
+                            btn.attr('data-applicant-id', r.id);
+                            row.append($('<td></td>').append(btn));
+                        }
                     } else {
-                        const btn = $('<button class="btn btn-sm btn-primary mark-viewed-btn">Mark Viewed</button>');
-                        btn.attr('data-applicant-id', r.id);
-                        row.append($('<td></td>').append(btn));
+                        row.append($('<td></td>'));
+                        row.append($('<td></td>'));
+                        row.append($('<td></td>'));
+                        row.append($('<td class="status"></td>').text('Pending Review'));
+                        row.append($('<td></td>'));
                     }
+
                     tbody.append(row);
                 });
                 $('#datatable-review-inbox').DataTable({


### PR DESCRIPTION
## Summary
- Include quest applications without reviews in quest giver review inbox API
- Track whether each application has a review and return flag to client
- Render pending reviews on quest giver dashboard and suppress mark-viewed button until review exists

## Testing
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/quest-giver-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_68c6f06a198483338ec77c6038f35d62