### PR TITLE
Add claim-all review feature with host rewards

### DIFF
--- a/html/api/v1/engine/quest/claimAllReviews.php
+++ b/html/api/v1/engine/quest/claimAllReviews.php
@@ -1,0 +1,27 @@
+<?php
+require_once(__DIR__ . '/../../engine/engine.php');
+
+use Kickback\Backend\Controllers\AccountController;
+use Kickback\Backend\Controllers\QuestController;
+use Kickback\Backend\Config\ServiceCredentials;
+use Kickback\Backend\Views\vRecordId;
+use Kickback\Backend\Models\Response;
+
+OnlyPOST();
+
+$contains = POSTContainsFields('sessionToken');
+if (!$contains->success) {
+    return $contains;
+}
+
+$sessionToken = Validate($_POST['sessionToken']);
+
+$kk_service_key = ServiceCredentials::get('kk_service_key');
+$loginResp = AccountController::getAccountBySession($kk_service_key, $sessionToken);
+if (!$loginResp->success) {
+    return $loginResp;
+}
+$account = $loginResp->data;
+
+return QuestController::claimAllReviews(new vRecordId('', $account->crand));
+?>

--- a/html/api/v1/quest/claimAllReviews.php
+++ b/html/api/v1/quest/claimAllReviews.php
@@ -1,0 +1,5 @@
+<?php
+$resp = require(__DIR__ . '/../engine/quest/claimAllReviews.php');
+
+$resp->Return();
+?>

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -778,6 +778,7 @@ function renderStarRating(float $rating): string
                 </div>
                 <div class="tab-pane fade" id="nav-review-inbox" role="tabpanel" aria-labelledby="nav-review-inbox-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Review Inbox</div>
+                    <button id="claim-all-reviews" class="btn btn-sm btn-success mb-2">Claim All</button>
                     <div class="table-responsive">
                         <table id="datatable-review-inbox" class="table table-striped">
                             <thead>
@@ -1585,7 +1586,20 @@ $(document).ready(function () {
 
     loadReviewInbox();
 
+    $('#claim-all-reviews').on('click', function () {
+        $.post('/api/v1/quest/claimAllReviews.php', { sessionToken: sessionToken }, function(resp) {
+            if (resp.success) {
+                loadReviewInbox();
+            } else {
+                alert(resp.message);
+            }
+        }, 'json');
+    });
+
     function loadReviewInbox() {
+        if ($.fn.DataTable.isDataTable('#datatable-review-inbox')) {
+            $('#datatable-review-inbox').DataTable().destroy();
+        }
         $.post('/api/v1/quest/reviewInbox.php', { sessionToken: sessionToken }, function(resp) {
             if (resp.success) {
                 const tbody = $('#datatable-review-inbox tbody');


### PR DESCRIPTION
## Summary
- add claim-all button to review inbox that marks all unviewed reviews as viewed
- award host rewards based on review ratings
- expose claim-all reviews API endpoint

## Testing
- `php -l html/api/v1/quest/claimAllReviews.php`
- `php -l html/api/v1/engine/quest/claimAllReviews.php`
- `php -l html/Kickback/Backend/Controllers/QuestController.php`
- `php -l html/quest-giver-dashboard.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68c6f5a4e58c833387c54f847fae1829