### PR TITLE
Filter out host-authored reviews from inbox

### DIFF
--- a/html/Kickback/Backend/Controllers/QuestController.php
+++ b/html/Kickback/Backend/Controllers/QuestController.php
@@ -2074,7 +2074,9 @@ class QuestController
                 JOIN v_quest_info q ON qa.quest_id = q.Id
                 JOIN v_account_info acc ON qa.account_id = acc.Id
                 WHERE qa.participated = 1
-                  AND (q.host_id = ? OR q.host_id_2 = ?)';
+                  AND (q.host_id = ? OR q.host_id_2 = ?)
+                  AND qa.account_id <> q.host_id
+                  AND (q.host_id_2 IS NULL OR qa.account_id <> q.host_id_2)';
         $stmt = $conn->prepare($sql);
         if ($stmt === false) {
             return new Response(false, 'Failed to prepare query.', null);


### PR DESCRIPTION
## Summary
- prevent quest givers from seeing reviews they wrote for their own quests

## Testing
- `composer install` (fails: CONNECT tunnel failed 403)
- `php -l html/Kickback/Backend/Controllers/QuestController.php`


------
https://chatgpt.com/codex/tasks/task_b_68c6fc830fc88333b5a6f2e9e61a7965