### PR TITLE
Fix schedule calendar cell layout

### DIFF
--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -1120,8 +1120,12 @@ animation: confetti-fast 1.25s linear 1 forwards;
     height: 120px;
     vertical-align: top;
     padding: 0.25rem;
+}
+
+#scheduleCalendar td .schedule-calendar-cell {
     display: flex;
     flex-direction: column;
+    height: 100%;
 }
 
 .calendar-today {

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1381,7 +1381,8 @@ $(document).ready(function () {
                 const pillClass = otherHost ? 'bg-secondary' : 'bg-primary';
                 pills += `<div class=\"badge ${pillClass} rounded-pill text-truncate mb-1 calendar-event-pill\" data-bs-toggle=\"tooltip\" title=\"${pillTip.replace(/\"/g,'&quot;')}\">${time}</div>`;
             });
-            body += `<td class="${cls}" ${tooltip}><div class="fw-bold">${date.getDate()}</div>${pills}${(!events.length && count) ? `<small>${count} participants</small>` : ''}</td>`;
+            const countInfo = (!events.length && count) ? `<small>${count} participants</small>` : '';
+            body += `<td class="${cls}" ${tooltip}><div class="schedule-calendar-cell"><div class="fw-bold">${date.getDate()}</div>${pills}${countInfo}</div></td>`;
             if (date.getDay() === 6) { body += '</tr><tr>'; }
             date.setDate(date.getDate()+1);
         }


### PR DESCRIPTION
## Summary
- keep the schedule calendar table cells using their default table layout while keeping the flex stacking inside a wrapper
- wrap rendered calendar contents in a flex column container so dates, pills, and counts remain vertically stacked

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_b_68c9b903f8988333ae3a64b4b02c9aaa