### PR TITLE
Fix loot helpers to use record IDs

### DIFF
--- a/html/Kickback/Backend/Controllers/LootController.php
+++ b/html/Kickback/Backend/Controllers/LootController.php
@@ -609,7 +609,7 @@ class LootController
     }
 
     public static function givePrestigeToken(vRecordId $account_id) : Response {
-        return self::giveLoot($account_id, 3);
+        return self::giveLoot($account_id, new vRecordId('', 3));
     }
 
     public static function giveBadge(vRecordId $account_id, vRecordId $item_id) : Response {
@@ -617,7 +617,7 @@ class LootController
     }
 
     public static function giveRaffleTicket(vRecordId $account_id) : Response {
-        return self::giveLoot($account_id, 4);
+        return self::giveLoot($account_id, new vRecordId('', 4));
     }
 
     public static function giveWritOfPassage(vRecordId $account_id) : Response {


### PR DESCRIPTION
## Summary
- ensure loot helpers pass vRecordId instances for fixed reward items

## Testing
- php -l html/Kickback/Backend/Controllers/LootController.php

------
https://chatgpt.com/codex/tasks/task_b_68ca11077f3c8333948ea72a40e819ff