### PR TITLE
Make quest editing modals non-dismissible

### DIFF
--- a/html/php-components/content-viewer.php
+++ b/html/php-components/content-viewer.php
@@ -26,7 +26,7 @@ if ($_vCanEditContent)
 ?>
 
 <!-- EDIT CODE MODAL -->
-<div class="modal modal-lg fade" id="modalEditCode" tabindex="-1" aria-labelledby="modalEditCodeLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditCode" tabindex="-1" aria-labelledby="modalEditCodeLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -46,7 +46,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- NEW ELEMENT MODAL -->
-<div class="modal modal-lg fade" id="modalNewElement" tabindex="-1" aria-labelledby="modalNewElementLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalNewElement" tabindex="-1" aria-labelledby="modalNewElementLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -75,7 +75,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- EDIT TITLE MODAL -->
-<div class="modal modal-lg fade" id="modalEditTitle" tabindex="-1" aria-labelledby="modalEditTitleLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditTitle" tabindex="-1" aria-labelledby="modalEditTitleLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -95,7 +95,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- EDIT SUBTITLE MODAL -->
-<div class="modal modal-lg fade" id="modalEditSubtitle" tabindex="-1" aria-labelledby="modalEditSubtitleLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditSubtitle" tabindex="-1" aria-labelledby="modalEditSubtitleLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -116,7 +116,7 @@ if ($_vCanEditContent)
 
 
 <!-- EDIT HEADER MODAL -->
-<div class="modal modal-lg fade" id="modalEditHeader" tabindex="-1" aria-labelledby="modalEditHeaderLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditHeader" tabindex="-1" aria-labelledby="modalEditHeaderLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -136,7 +136,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- EDIT PARAGRAPH MODAL -->
-<div class="modal modal-lg fade" id="modalEditParagraph" tabindex="-1" aria-labelledby="modalEditParagraphLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditParagraph" tabindex="-1" aria-labelledby="modalEditParagraphLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -156,7 +156,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- EDIT LIST MODAL -->
-<div class="modal modal-lg fade" id="modalEditList" tabindex="-1" aria-labelledby="modalEditListLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditList" tabindex="-1" aria-labelledby="modalEditListLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
@@ -192,7 +192,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- EDIT MEDIA MODAL -->
-<div class="modal modal-lg fade" id="modalEditMedia" tabindex="-1" aria-labelledby="modalEditMediaLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditMedia" tabindex="-1" aria-labelledby="modalEditMediaLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
@@ -231,7 +231,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- EDIT YOUTUBE MODAL -->
-<div class="modal modal-lg fade" id="modalEditYoutube" tabindex="-1" aria-labelledby="modalEditYoutubeLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditYoutube" tabindex="-1" aria-labelledby="modalEditYoutubeLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
@@ -270,7 +270,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- EDIT SKETCH FAB MODAL -->
-<div class="modal modal-lg fade" id="modalEditSketchFab" tabindex="-1" aria-labelledby="modalEditSketchFabLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditSketchFab" tabindex="-1" aria-labelledby="modalEditSketchFabLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
@@ -318,7 +318,7 @@ if ($_vCanEditContent)
 </div>
 
 <!-- EDIT SLIDER MODAL -->
-<div class="modal modal-lg fade" id="modalEditSlider" tabindex="-1" aria-labelledby="modalEditSliderLabel" aria-hidden="true">
+<div class="modal modal-lg fade" id="modalEditSlider" tabindex="-1" aria-labelledby="modalEditSliderLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">

--- a/html/quest-line.php
+++ b/html/quest-line.php
@@ -190,7 +190,7 @@ $thisQuestLine->populateEverything();
                             <input type="hidden" value="<?php echo $thisQuestLine->banner->crand; ?>" name="edit-quest-line-images-desktop-banner-id" id="edit-quest-line-images-desktop-banner-id"/>
                             <input type="hidden" value="<?php echo $thisQuestLine->bannerMobile->crand; ?>" name="edit-quest-line-images-mobile-banner-id" id="edit-quest-line-images-mobile-banner-id" />
                             <input type="hidden" value="<?php echo $thisQuestLine->icon->crand; ?>" name="edit-quest-line-images-icon-id" id="edit-quest-line-images-icon-id"/>
-                            <div class="modal modal-lg fade" id="modalEditQuestImages" tabindex="-1" aria-labelledby="modalEditQuestImagesLabel" aria-hidden="true">
+                            <div class="modal modal-lg fade" id="modalEditQuestImages" tabindex="-1" aria-labelledby="modalEditQuestImagesLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header">
@@ -231,7 +231,7 @@ $thisQuestLine->populateEverything();
                         <form method="POST">
                             <input type="hidden" value="<?= $thisQuestLine->crand; ?>" name="edit-quest-line-id" />
                             <input type="hidden" name="form_token" value="<?php echo $_SESSION['form_token']; ?>">
-                            <div class="modal modal-lg fade" id="modalEditQuestOptions" tabindex="-1" aria-labelledby="modalEditQuestOptionsLabel" aria-hidden="true">
+                            <div class="modal modal-lg fade" id="modalEditQuestOptions" tabindex="-1" aria-labelledby="modalEditQuestOptionsLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header">
@@ -301,7 +301,7 @@ $thisQuestLine->populateEverything();
                         <form method="POST">
                             <input type="hidden" name="form_token" value="<?= $_SESSION['form_token']; ?>">
                             <input type="hidden" name="quest-line-id" value="<?= $thisQuestLine->crand; ?>" />
-                            <div class="modal modal-xl fade" id="modalQuestPublish" tabindex="-1" aria-labelledby="modalQuestPublishLabel" aria-hidden="true">
+                            <div class="modal modal-xl fade" id="modalQuestPublish" tabindex="-1" aria-labelledby="modalQuestPublishLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header">
@@ -370,7 +370,7 @@ $thisQuestLine->populateEverything();
                         <form method="POST">
                             <input type="hidden" name="form_token" value="<?= $_SESSION['form_token']; ?>">
                             <input type="hidden" name="quest-line-id" value="<?= $thisQuestLine->crand; ?>" />
-                            <div class="modal modal-xl fade" id="modalQuestApprove" tabindex="-1" aria-labelledby="modalQuestApproveLabel" aria-hidden="true">
+                            <div class="modal modal-xl fade" id="modalQuestApprove" tabindex="-1" aria-labelledby="modalQuestApproveLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header bg-success">
@@ -401,7 +401,7 @@ $thisQuestLine->populateEverything();
                         <form method="POST">
                             <input type="hidden" name="form_token" value="<?= $_SESSION['form_token']; ?>">
                             <input type="hidden" name="quest-line-id" value="<?= $thisQuestLine->crand; ?>" />
-                            <div class="modal modal-xl fade" id="modalQuestReject" tabindex="-1" aria-labelledby="modalQuestRejectLabel" aria-hidden="true">
+                            <div class="modal modal-xl fade" id="modalQuestReject" tabindex="-1" aria-labelledby="modalQuestRejectLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header bg-danger">

--- a/html/quest.php
+++ b/html/quest.php
@@ -491,7 +491,7 @@ $itemInformationJSON = json_encode($itemInfos);
                         <form method="POST">
                             <input type="hidden" name="form_token" value="<?php echo $_SESSION['form_token']; ?>">
                             <input type="hidden" value="<?= $thisQuest->crand; ?>" name="edit-quest-id" />
-                            <div class="modal modal-lg fade" id="modalEditQuestRewards" tabindex="-1" aria-labelledby="modalEditQuestRewardsLabel" aria-hidden="true">
+                            <div class="modal modal-lg fade" id="modalEditQuestRewards" tabindex="-1" aria-labelledby="modalEditQuestRewardsLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header">
@@ -574,7 +574,7 @@ $itemInformationJSON = json_encode($itemInfos);
                             <input type="hidden" value="<?= $thisQuest->banner->crand; ?>" name="edit-quest-images-desktop-banner-id" id="edit-quest-images-desktop-banner-id"/>
                             <input type="hidden" value="<?= $thisQuest->bannerMobile->crand; ?>" name="edit-quest-images-mobile-banner-id" id="edit-quest-images-mobile-banner-id" />
                             <input type="hidden" value="<?= $thisQuest->icon->crand; ?>" name="edit-quest-images-icon-id" id="edit-quest-images-icon-id"/>
-                            <div class="modal modal-lg fade" id="modalEditQuestImages" tabindex="-1" aria-labelledby="modalEditQuestImagesLabel" aria-hidden="true">
+                            <div class="modal modal-lg fade" id="modalEditQuestImages" tabindex="-1" aria-labelledby="modalEditQuestImagesLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header">
@@ -616,7 +616,7 @@ $itemInformationJSON = json_encode($itemInfos);
                             <input type="hidden" name="form_token" value="<?php echo $_SESSION['form_token']; ?>">
                             <input type="hidden" value="<?= $thisQuest->crand; ?>" name="edit-quest-id" />
                             <input type="hidden" value="<?= $thisQuest->getHost2Id(); ?>" name="edit-quest-options-host-2-id" id="edit-quest-options-host-2-id"/>
-                            <div class="modal modal-lg fade" id="modalEditQuestOptions" tabindex="-1" aria-labelledby="modalEditQuestOptionsLabel" aria-hidden="true">
+                            <div class="modal modal-lg fade" id="modalEditQuestOptions" tabindex="-1" aria-labelledby="modalEditQuestOptionsLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header">
@@ -1016,7 +1016,7 @@ $itemInformationJSON = json_encode($itemInfos);
                         <form method="POST">
                             <input type="hidden" name="form_token" value="<?php echo $_SESSION['form_token']; ?>">
                             <input type="hidden" name="quest-id" value="<?= $thisQuest->crand; ?>" />
-                            <div class="modal modal-xl fade" id="modalQuestPublish" tabindex="-1" aria-labelledby="modalQuestPublishLabel" aria-hidden="true">
+                            <div class="modal modal-xl fade" id="modalQuestPublish" tabindex="-1" aria-labelledby="modalQuestPublishLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                     <div class="modal-header">
@@ -1090,7 +1090,7 @@ $itemInformationJSON = json_encode($itemInfos);
                         <form method="POST">
                             <input type="hidden" name="form_token" value="<?= $_SESSION['form_token']; ?>">
                             <input type="hidden" name="quest-id" value="<?= $thisQuest->crand; ?>" />
-                            <div class="modal modal-xl fade" id="modalQuestApprove" tabindex="-1" aria-labelledby="modalQuestApproveLabel" aria-hidden="true">
+                            <div class="modal modal-xl fade" id="modalQuestApprove" tabindex="-1" aria-labelledby="modalQuestApproveLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header bg-success">
@@ -1121,7 +1121,7 @@ $itemInformationJSON = json_encode($itemInfos);
                         <form method="POST">
                             <input type="hidden" name="form_token" value="<?= $_SESSION['form_token']; ?>">
                             <input type="hidden" name="quest-id" value="<?= $thisQuest->crand; ?>" />
-                            <div class="modal modal-xl fade" id="modalQuestReject" tabindex="-1" aria-labelledby="modalQuestRejectLabel" aria-hidden="true">
+                            <div class="modal modal-xl fade" id="modalQuestReject" tabindex="-1" aria-labelledby="modalQuestRejectLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <div class="modal-header bg-danger">


### PR DESCRIPTION
## Summary
- prevent quest edit modals from closing on backdrop clicks or escape key presses
- apply the same non-dismissible behavior to quest line management modals
- enforce consistent non-dismissible behavior across all content editor modals

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68cc4b1bf8f08333bd6388fdcfa61273