### PR TITLE
Implement quest co-host selection flow

### DIFF
--- a/html/php-components/base-page-javascript-account-search.php
+++ b/html/php-components/base-page-javascript-account-search.php
@@ -7,6 +7,7 @@ use Kickback\Common\Version;
 <script>
 
 var selectAccountModalCallerId = -1;
+var selectAccountResultsById = {};
 
 function OpenSelectAccountModal(prevModal = null, clickableFunction = null) {
 
@@ -89,6 +90,7 @@ function ClearSearchAccountResults(formId)
 
     $("#"+formId+"selectUserPagination").html("");
     $("#" + formId + "selectAccountLoadingSpinner").show();
+    selectAccountResultsById = {};
 }
 
 
@@ -98,10 +100,14 @@ function AddSearchAccountResult(formId, account, clickableFunction = null) {
 
     // Append the card to the results container
     //$("#"+formId+"selectAccountSearchResults").append(cardHtml);
-    
+
     // Append the card to the results container
     var container = $("#"+formId+"selectAccountSearchResults");
     container.append(cardHtml);
+
+    if (account && account.crand !== undefined) {
+        selectAccountResultsById[account.crand] = account;
+    }
 
     // Initialize tooltips for the newly appended card
     container.find('.player-card').last().find('[data-bs-toggle="tooltip"]').tooltip();
@@ -173,7 +179,15 @@ for (var i = ranks; i < 5; i ++ )
 ">X / X</span></div>`;
 
 }
-const clickableLayer = clickableFunction ? `<div class="clickable-layer" onclick="${clickableFunction}(${playerCardAccount.crand})"></div>` : '';
+const sanitizedUsernameAttr = playerCardAccount.username
+    ? playerCardAccount.username.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+    : '';
+
+const accountIdAttr = String(playerCardAccount.crand ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+const clickableLayer = clickableFunction
+    ? `<div class="clickable-layer" data-account-id="${accountIdAttr}" data-username="${sanitizedUsernameAttr}" onclick='${clickableFunction}(${JSON.stringify(playerCardAccount.crand)})'></div>`
+    : '';
 
 let playerCardHTML = `<div class="card player-card${isRanked1 ? " ranked-1" : ""}">
 ${clickableLayer}

--- a/html/quest.php
+++ b/html/quest.php
@@ -645,8 +645,9 @@ $itemInformationJSON = json_encode($itemInfos);
                                                     <label for="edit-quest-options-locator" class="form-label">Co-Host:</label>
                                                     <div class="input-group">
                                                         <span class="input-group-text"><i class="fa-solid fa-user-plus"></i></span>
-                                                        <input type="text" disabled class="form-control" value="<?= $thisQuest->getHost2Username(); ?>" />
-                                                        <button type="button" class="btn btn-primary" onclick="OpenSelectAccountModal('modalEditQuestOptions')">Select</button>
+                                                        <input type="text" disabled class="form-control" id="edit-quest-options-host-2-username" value="<?= $thisQuest->getHost2Username(); ?>" placeholder="No co-host selected" />
+                                                        <button type="button" class="btn btn-outline-secondary" onclick="SelectQuestCoHost('')">Clear</button>
+                                                        <button type="button" class="btn btn-primary" onclick="OpenSelectAccountModal('modalEditQuestOptions','SelectQuestCoHost')">Select</button>
                                                     </div>
                                                 </div>
                                                 <div class="col-lg-6 mb-3">
@@ -814,6 +815,72 @@ $itemInformationJSON = json_encode($itemInfos);
                                                                         if (radioElement.checked && selectedQuestStyle == '1') {
                                                                             bracketOptions.style.display = "block";
                                                                         }
+                                                                    }
+
+                                                                    function SelectQuestCoHost(accountId) {
+                                                                        const coHostIdInput = document.getElementById('edit-quest-options-host-2-id');
+                                                                        const coHostNameInput = document.getElementById('edit-quest-options-host-2-username');
+
+                                                                        if (!coHostIdInput || !coHostNameInput) {
+                                                                            return;
+                                                                        }
+
+                                                                        const selectedId = accountId ?? '';
+                                                                        let normalizedId = selectedId === null ? '' : selectedId.toString().trim();
+                                                                        if (normalizedId === 'undefined' || normalizedId === 'null') {
+                                                                            normalizedId = '';
+                                                                        }
+                                                                        coHostIdInput.value = normalizedId;
+
+                                                                        let selectedUsername = '';
+
+                                                                        if (normalizedId !== '') {
+                                                                            if (typeof selectAccountResultsById !== 'undefined') {
+                                                                                const accountInfo = selectAccountResultsById[normalizedId];
+                                                                                if (accountInfo && accountInfo.username) {
+                                                                                    selectedUsername = accountInfo.username;
+                                                                                }
+                                                                            }
+
+                                                                            if (!selectedUsername) {
+                                                                                const clickableLayer = document.querySelector(`#modal-selectAccountSearchResults .clickable-layer[data-account-id="${normalizedId.replace(/"/g, '\"')}"]`);
+                                                                                if (clickableLayer && clickableLayer.dataset.username) {
+                                                                                    selectedUsername = decodeHtml(clickableLayer.dataset.username);
+                                                                                }
+                                                                            }
+                                                                        }
+
+                                                                        coHostNameInput.value = selectedUsername;
+
+                                                                        const selectModalElement = document.getElementById('selectAccountModal');
+                                                                        const modalWasOpen = selectModalElement && selectModalElement.classList.contains('show');
+
+                                                                        if (modalWasOpen && typeof bootstrap !== 'undefined' && bootstrap.Modal) {
+                                                                            let selectModalInstance = bootstrap.Modal.getInstance(selectModalElement);
+                                                                            if (!selectModalInstance) {
+                                                                                selectModalInstance = new bootstrap.Modal(selectModalElement);
+                                                                            }
+                                                                            selectModalInstance.hide();
+
+                                                                            if (selectAccountModalCallerId && selectAccountModalCallerId !== -1) {
+                                                                                const previousModalElement = document.getElementById(selectAccountModalCallerId);
+                                                                                if (previousModalElement) {
+                                                                                    let previousModalInstance = bootstrap.Modal.getInstance(previousModalElement);
+                                                                                    if (!previousModalInstance) {
+                                                                                        previousModalInstance = new bootstrap.Modal(previousModalElement);
+                                                                                    }
+                                                                                    previousModalInstance.show();
+                                                                                }
+                                                                            }
+
+                                                                            selectAccountModalCallerId = -1;
+                                                                        }
+                                                                    }
+
+                                                                    function decodeHtml(value) {
+                                                                        const textarea = document.createElement('textarea');
+                                                                        textarea.innerHTML = value;
+                                                                        return textarea.value;
                                                                     }
 
                                                                     function toggleDateTimeVisibility() {


### PR DESCRIPTION
## Summary
- add clear/select controls and wiring for the quest co-host field so the modal invokes the new handler
- implement `SelectQuestCoHost` to populate form fields, manage modal transitions, and support clearing a co-host
- cache search results and annotate account cards with metadata to recover usernames when a co-host is chosen

## Testing
- php -l html/quest.php
- php -l html/php-components/base-page-javascript-account-search.php

------
https://chatgpt.com/codex/tasks/task_b_68cc788288408333a335862b93164135