### PR TITLE
Fix header modal input id and rendering

### DIFF
--- a/html/php-components/content-viewer-javascript.php
+++ b/html/php-components/content-viewer-javascript.php
@@ -360,7 +360,7 @@
                 break;
 
             case 11:
-                //header
+                OpenEditModal_Header(index);
                 break;
             case 12:
                 //button link
@@ -633,8 +633,7 @@
                 break;
 
             case 11:
-                //header
-                htmlContent = `<p>Error with element: ${JSON.stringify(contentElement)}</p>`;
+                htmlContent = `<h2 class="display-6">${GetContentElementData(contentElement)}</h2>`;
                 break;
 
             case 12:

--- a/html/php-components/content-viewer.php
+++ b/html/php-components/content-viewer.php
@@ -124,8 +124,8 @@ if ($_vCanEditContent)
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <label for="content-edit-heaeder-textbox" class="form-label">Enter a Header</label>
-        <input class="form-control form-control-lg" type="text" id="content-edit-heaeder-textbox">
+        <label for="content-edit-header-textbox" class="form-label">Enter a Header</label>
+        <input class="form-control form-control-lg" type="text" id="content-edit-header-textbox">
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>


### PR DESCRIPTION
## Summary
- correct the header modal input id to match JavaScript selectors
- wire header content elements into the editor modal switch logic
- render header elements with a smaller display style to differentiate them from titles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cc9f6bf5648333b49e13d87f4cf141