### PR TITLE
Improve markdown code block styling and copy button

### DIFF
--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -1164,14 +1164,16 @@ animation: confetti-fast 1.25s linear 1 forwards;
 
 .markdown-pre,
 .markdown-content pre {
-    background-color: #1e1e1e;
-    color: #f8f9fa;
+    background-color: #111827;
+    color: #f8fafc;
+    border: 1px solid rgba(148, 163, 184, 0.35);
     border-radius: 0.5rem;
     padding: 1rem;
     overflow: auto;
     font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, "Liberation Mono", 'Courier New', monospace;
     font-size: 0.875rem;
     position: relative;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.15);
 }
 
 .markdown-content pre code,
@@ -1193,14 +1195,21 @@ animation: confetti-fast 1.25s linear 1 forwards;
 
 .markdown-copy-button {
     position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
-    padding: 0.25rem 0.75rem;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+    top: 0.6rem;
+    right: 0.6rem;
+    padding: 0.35rem;
+    font-size: 0.875rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.375rem;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out, color 0.2s ease-in-out;
     opacity: 0.8;
+}
+
+.markdown-copy-button i {
+    pointer-events: none;
 }
 
 .markdown-code-block:hover .markdown-copy-button {

--- a/html/php-components/content-viewer-javascript.php
+++ b/html/php-components/content-viewer-javascript.php
@@ -1049,8 +1049,9 @@
             copyButton.type = 'button';
             copyButton.className = 'btn btn-sm btn-outline-secondary markdown-copy-button';
             copyButton.setAttribute('aria-label', 'Copy code');
+            copyButton.setAttribute('title', 'Copy code');
             copyButton.setAttribute('data-code-text', code.textContent || '');
-            copyButton.textContent = 'Copy';
+            copyButton.innerHTML = '<i class="fa-regular fa-copy" aria-hidden="true"></i><span class="visually-hidden">Copy code</span>';
 
             wrapper.appendChild(copyButton);
         });
@@ -1071,19 +1072,29 @@
             return;
         }
 
-        const originalLabel = button.data('original-label') || button.text();
+        const originalLabel = button.data('original-label') || button.html();
+        const originalAria = button.data('original-aria') || button.attr('aria-label');
+        const originalTitle = button.data('original-title') || button.attr('title');
         button.data('original-label', originalLabel);
+        button.data('original-aria', originalAria);
+        button.data('original-title', originalTitle);
 
         const showFeedback = (text, stateClass) => {
-            button.text(text);
+            const iconClass = stateClass === 'copy-error' ? 'fa-solid fa-triangle-exclamation' : 'fa-solid fa-check';
+            const iconHtml = '<i class="' + iconClass + '" aria-hidden="true"></i><span class="visually-hidden">' + text + '</span>';
+            button.html(iconHtml);
+            button.attr('aria-label', text);
+            button.attr('title', text);
             button.removeClass('copy-success copy-error');
             if (stateClass) {
                 button.addClass(stateClass);
             }
 
             setTimeout(() => {
-                button.text(button.data('original-label'));
+                button.html(button.data('original-label'));
                 button.removeClass('copy-success copy-error');
+                button.attr('aria-label', button.data('original-aria') || 'Copy code');
+                button.attr('title', button.data('original-title') || 'Copy code');
             }, 2000);
         };
 


### PR DESCRIPTION
## Summary
- restyle markdown code blocks with a richer background, subtle border, and shadow for improved contrast
- reposition the markdown copy button, convert it to an icon-only control, and tweak hover styling
- update the markdown enhancement script to render the icon button and provide icon-based copy feedback states

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68ccad52b98c83338766c6260adc131b