### PR TITLE
Enhance markdown code blocks with VS Code styling

### DIFF
--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -1160,27 +1160,80 @@ animation: confetti-fast 1.25s linear 1 forwards;
 
 .markdown-code-block {
     margin: 1.5rem 0;
+    position: relative;
+}
+
+.markdown-code-wrapper {
+    display: flex;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background-color: #1e1e1e;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.15);
+    overflow: hidden;
+}
+
+.markdown-line-numbers {
+    background-color: #1b1b1b;
+    color: #6b7280;
+    padding: 1rem 0.75rem;
+    text-align: right;
+    font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, "Liberation Mono", 'Courier New', monospace;
+    font-size: 0.75rem;
+    line-height: 1.6;
+    border-right: 1px solid rgba(148, 163, 184, 0.35);
+    user-select: none;
+}
+
+.markdown-line-number {
+    display: block;
+    padding: 0 0.75rem 0 0.5rem;
+    min-width: 2.5ch;
+}
+
+.markdown-code-scroll {
+    flex: 1 1 auto;
+    overflow: auto;
+    position: relative;
 }
 
 .markdown-pre,
 .markdown-content pre {
-    background-color: #111827;
-    color: #f8fafc;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    border-radius: 0.5rem;
-    padding: 1rem;
-    overflow: auto;
+    background: transparent;
+    color: #d4d4d4;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+    margin: 0;
+    overflow: visible;
     font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, "Liberation Mono", 'Courier New', monospace;
     font-size: 0.875rem;
     position: relative;
-    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.15);
+    min-width: 100%;
 }
 
 .markdown-content pre code,
 .markdown-code {
     background: transparent;
     color: inherit;
-    padding: 0;
+    padding: 1rem 1.25rem;
+    display: block;
+}
+
+.markdown-code-line {
+    display: block;
+    padding: 0 1.25rem;
+    margin: 0 -1.25rem;
+    line-height: 1.6;
+    white-space: pre;
+    background-color: rgba(255, 255, 255, 0.02);
+}
+
+.markdown-code-line:nth-child(even) {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.markdown-code-line:hover {
+    background-color: rgba(120, 81, 169, 0.18);
 }
 
 .markdown-inline-code,

--- a/html/php-components/content-viewer-javascript.php
+++ b/html/php-components/content-viewer-javascript.php
@@ -1040,17 +1040,49 @@
             wrapper.className = 'markdown-code-block position-relative';
 
             pre.parentNode.insertBefore(wrapper, pre);
-            wrapper.appendChild(pre);
+
+            const codeWrapper = document.createElement('div');
+            codeWrapper.className = 'markdown-code-wrapper';
+            wrapper.appendChild(codeWrapper);
+
+            const lineNumberColumn = document.createElement('div');
+            lineNumberColumn.className = 'markdown-line-numbers';
+            codeWrapper.appendChild(lineNumberColumn);
+
+            const scrollContainer = document.createElement('div');
+            scrollContainer.className = 'markdown-code-scroll';
+            codeWrapper.appendChild(scrollContainer);
+            scrollContainer.appendChild(pre);
 
             pre.classList.add('markdown-pre');
             code.classList.add('markdown-code');
+
+            const codeText = code.textContent || '';
+            const normalizedCode = codeText.replace(/\r\n?/g, '\n');
+            const codeLines = normalizedCode.split('\n');
+            if (normalizedCode.endsWith('\n')) {
+                codeLines.push('');
+            }
+
+            code.innerHTML = '';
+            codeLines.forEach((line, index) => {
+                const lineNumber = document.createElement('span');
+                lineNumber.className = 'markdown-line-number';
+                lineNumber.textContent = String(index + 1);
+                lineNumberColumn.appendChild(lineNumber);
+
+                const lineSpan = document.createElement('span');
+                lineSpan.className = 'markdown-code-line';
+                lineSpan.textContent = line === '' ? '\u200B' : line;
+                code.appendChild(lineSpan);
+            });
 
             const copyButton = document.createElement('button');
             copyButton.type = 'button';
             copyButton.className = 'btn btn-sm btn-outline-secondary markdown-copy-button';
             copyButton.setAttribute('aria-label', 'Copy code');
             copyButton.setAttribute('title', 'Copy code');
-            copyButton.setAttribute('data-code-text', code.textContent || '');
+            copyButton.setAttribute('data-code-text', codeText);
             copyButton.innerHTML = '<i class="fa-regular fa-copy" aria-hidden="true"></i><span class="visually-hidden">Copy code</span>';
 
             wrapper.appendChild(copyButton);


### PR DESCRIPTION
## Summary
- add line-number rendering and alternating row backgrounds to markdown editor code blocks
- restyle the markdown code block container to mimic Visual Studio Code theming while keeping copy button support

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ccb2fc55e483338be4c9156d8e1554