### PR TITLE
Fix character sheet session verification

### DIFF
--- a/html/character-sheet.php
+++ b/html/character-sheet.php
@@ -1,7 +1,8 @@
 <?php
 require_once(($_SERVER["DOCUMENT_ROOT"] ?: __DIR__) . "/Kickback/init.php");
 
-$session = require("php-components/base-page-pull-active-account-info.php");
+$session = require(\Kickback\SCRIPT_ROOT . "/api/v1/engine/session/verifySession.php");
+require("php-components/base-page-pull-active-account-info.php");
 
 use Kickback\Services\Session;
 use Kickback\Backend\Controllers\AccountController;


### PR DESCRIPTION
## Summary
- ensure the character sheet page verifies the active session before loading account data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd940d90c08333a541bf086028eff1