### PR TITLE
Add account game stats retrieval helper

### DIFF
--- a/html/character-sheet.php
+++ b/html/character-sheet.php
@@ -9,6 +9,7 @@ use Kickback\Backend\Controllers\AccountController;
 use Kickback\Backend\Controllers\ActivityController;
 use Kickback\Backend\Controllers\LootController;
 use Kickback\Backend\Controllers\GameController;
+use Kickback\Backend\Views\vAccount;
 use Kickback\Backend\Views\vRecordId;
 
 $character = null;
@@ -31,6 +32,13 @@ if (Session::isLoggedIn()) {
             $character = $accountResp->data;
         } else {
             $character = $activeAccount;
+        }
+
+        if ($character instanceof vAccount) {
+            $gameStatsResp = AccountController::getAccountGameStats($activeAccount);
+            if ($gameStatsResp->success && is_array($gameStatsResp->data)) {
+                $character->game_stats = $gameStatsResp->data;
+            }
         }
 
         $badgesResp = LootController::getBadgesByAccount($activeAccount);


### PR DESCRIPTION
## Summary
- add AccountController::getAccountGameStats to return vGameStats records for an account
- update character sheet bootstrap to fetch the stats via the new controller helper when loading the page

## Testing
- php -l html/Kickback/Backend/Controllers/AccountController.php
- php -l html/character-sheet.php

------
https://chatgpt.com/codex/tasks/task_b_68cdad8b16e88333aabcc6f356ce31d8