### PR TITLE
Enable quest ranked tournament configuration

### DIFF
--- a/html/Kickback/Backend/Views/vTournament.php
+++ b/html/Kickback/Backend/Views/vTournament.php
@@ -21,6 +21,10 @@ class vTournament extends vRecordId
 {
     private bool $hasBracket_;
 
+    public ?int $gameId = null;
+    public ?string $name = null;
+    public ?string $description = null;
+
     /** @var ?array<vTournamentTeam> */
     private ?array $competitors_ = null;
 


### PR DESCRIPTION
## Summary
- add explicit ranked tournament radio options and game selection state handling in the quest editor
- persist tournament details on vTournament so the selected game can be restored when editing
- create or update tournament records when ranked tournaments are saved and link them to the quest

## Testing
- php -l html/quest.php
- php -l html/Kickback/Backend/Controllers/QuestController.php
- php -l html/Kickback/Backend/Views/vTournament.php

------
https://chatgpt.com/codex/tasks/task_b_68cec0d5ad0c8333b21b9d11722f1edb