### PR TITLE
Implement ranked tournament options for quests

### DIFF
--- a/html/Kickback/Backend/Views/vTournament.php
+++ b/html/Kickback/Backend/Views/vTournament.php
@@ -16,10 +16,17 @@ use Kickback\Backend\Views\vTournamentTeam;
 use Kickback\Backend\Views\vTournamentResult;
 use Kickback\Backend\Views\vAccount;
 use Kickback\Backend\Views\vQuestApplicant;
+use Kickback\Backend\Views\vGame;
+use Kickback\Backend\Views\vDateTime;
 
 class vTournament extends vRecordId
 {
     private bool $hasBracket_;
+
+    public string $name = '';
+    public string $description = '';
+    public ?vDateTime $date = null;
+    public ?vGame $game = null;
 
     /** @var ?array<vTournamentTeam> */
     private ?array $competitors_ = null;


### PR DESCRIPTION
## Summary
- replace the ranked quest radio buttons with a dropdown and wire up game selection requirements in the quest editor
- create or update tournament records when saving ranked quests and persist the selected game/has-bracket flag
- expose tournament metadata, including the associated game, so the quest form can preload existing selections

## Testing
- php -l html/quest.php
- php -l html/Kickback/Backend/Controllers/QuestController.php
- php -l html/Kickback/Backend/Controllers/TournamentController.php
- php -l html/Kickback/Backend/Views/vTournament.php

------
https://chatgpt.com/codex/tasks/task_b_68cec683c9e483338e81bd083bbd6f11