### PR TITLE
Allow ranked options editing until quest begins

### DIFF
--- a/html/Kickback/Backend/Controllers/QuestController.php
+++ b/html/Kickback/Backend/Controllers/QuestController.php
@@ -960,13 +960,15 @@ class QuestController
         $existingTournamentId = $quest->isTournament() ? $quest->tournament->crand : null;
         $tournamentIdValue = null;
 
-        $canEditRankedOptions = !$quest->reviewStatus->isPublished();
-        if ($canEditRankedOptions && $quest->hasEndDate()) {
+        $questHasBegun = false;
+        if ($quest->hasEndDate()) {
             $questEndDate = $quest->nullableEndDate();
             if ($questEndDate instanceof vDateTime) {
-                $canEditRankedOptions = $questEndDate->isAfter(vDateTime::now());
+                $questHasBegun = $questEndDate->isSameOrBefore(vDateTime::now());
             }
         }
+
+        $canEditRankedOptions = !($quest->reviewStatus->isPublished() && $questHasBegun);
 
         if (!$canEditRankedOptions) {
             if ($quest->isTournament()) {

--- a/html/quest.php
+++ b/html/quest.php
@@ -211,13 +211,15 @@ if ($thisQuest->isTournament())
     }
 }
 
-$rankedOptionsEditable = !$thisQuest->reviewStatus->isPublished();
-if ($rankedOptionsEditable && $thisQuest->hasEndDate()) {
+$questHasBegun = false;
+if ($thisQuest->hasEndDate()) {
     $questEndDate = $thisQuest->nullableEndDate();
     if ($questEndDate instanceof vDateTime) {
-        $rankedOptionsEditable = $questEndDate->isAfter(vDateTime::now());
+        $questHasBegun = $questEndDate->isSameOrBefore(vDateTime::now());
     }
 }
+
+$rankedOptionsEditable = !($thisQuest->reviewStatus->isPublished() && $questHasBegun);
 
 ?>
 
@@ -1016,7 +1018,7 @@ if ($rankedOptionsEditable && $thisQuest->hasEndDate()) {
                                                             <h5 class="card-title">Ranked Options</h5>
                                                             <?php if (!$rankedOptionsEditable) { ?>
                                                                 <div class="alert alert-warning mb-3" role="alert">
-                                                                    Ranked settings are locked once a quest is published or has begun.
+                                                                    Ranked settings are locked once a quest is published and has begun.
                                                                 </div>
                                                             <?php } ?>
                                                             


### PR DESCRIPTION
## Summary
- allow ranked options to remain editable after publish until the quest start time has passed
- update both the quest page UI and quest update controller to share the new published-and-started requirement
- clarify the on-page warning to mention the updated "published and begun" lock condition

## Testing
- php -l html/quest.php
- php -l html/Kickback/Backend/Controllers/QuestController.php

------
https://chatgpt.com/codex/tasks/task_b_68cef1958d18833384c7e9e5a3bfce77