### PR TITLE
Add quest giver dashboard CTA to quest reviewed notifications

### DIFF
--- a/html/php-components/base-page-components-notifications.php
+++ b/html/php-components/base-page-components-notifications.php
@@ -1,5 +1,6 @@
-<?php 
+<?php
 use Kickback\Backend\Models\NotificationType;
+use Kickback\Common\Version;
         
             if (Kickback\Services\Session::isLoggedIn() && !is_null($activeAccountInfo->notifications))
             {
@@ -61,8 +62,12 @@ use Kickback\Backend\Models\NotificationType;
                                     break;
                                 
                                 case NotificationType::QUEST_REVIEWED:
-                                    ?> 
-                                        <!--<div class="toast-body"><a class="bg-ranked-1 btn btn-sm" href="#">View</a></div>-->
+                                    ?>
+                                        <div class="toast-body">
+                                            <a class="bg-ranked-1 btn btn-sm" href="<?php echo Version::urlBetaPrefix(); ?>/quest-giver-dashboard.php">
+                                                <i class="fa-solid fa-chess-knight"></i> Quest Giver Dashboard
+                                            </a>
+                                        </div>
                                     <?php
                                     break;
                                 case NotificationType::PRESTIGE:


### PR DESCRIPTION
## Summary
- import the Version helper into the notifications component
- add a Quest Giver Dashboard call-to-action button to Quest Reviewed notifications

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cefff2c3b883338299aac6ccc5e1a8