### PR TITLE
Refactor quest giver dashboard to load via API

### DIFF
--- a/html/Kickback/Backend/Services/QuestDashboardService.php
+++ b/html/Kickback/Backend/Services/QuestDashboardService.php
@@ -818,21 +818,27 @@ class QuestDashboardService
 
         $upcoming = array_map(function (vQuest $quest): array {
             $card = FeedCardController::vQuest_to_vFeedCard($quest);
-            return self::feedCardToArray($card);
+            $cardData = self::feedCardToArray($card);
+            $cardData['questId'] = $quest->crand;
+            $cardData['questLocator'] = $quest->locator;
+            return $cardData;
         }, $raw['futureQuests']);
 
         $reviewSummaries = array_map(
-            static fn(vQuestReviewSummary $summary): array => [
-                'questId' => $summary->questId,
-                'questLocator' => $summary->questLocator,
-                'questTitle' => $summary->questTitle,
-                'questEndDate' => $summary->questEndDate,
-                'questIcon' => $summary->questIcon,
-                'questBanner' => $summary->questBanner,
-                'avgHostRating' => $summary->avgHostRating,
-                'avgQuestRating' => $summary->avgQuestRating,
-                'hasComments' => $summary->hasComments,
-            ],
+            static function (vQuestReviewSummary $summary): array {
+                $endDate = new vDateTime($summary->questEndDate);
+                return [
+                    'questId' => $summary->questId,
+                    'questLocator' => $summary->questLocator,
+                    'questTitle' => $summary->questTitle,
+                    'questEndDate' => self::formatDateTime($endDate),
+                    'questIcon' => $summary->questIcon,
+                    'questBanner' => $summary->questBanner,
+                    'avgHostRating' => $summary->avgHostRating,
+                    'avgQuestRating' => $summary->avgQuestRating,
+                    'hasComments' => $summary->hasComments,
+                ];
+            },
             $data['reviews']['summaries']
         );
 

--- a/html/assets/js/questGiverDashboard.js
+++ b/html/assets/js/questGiverDashboard.js
@@ -1,0 +1,634 @@
+(function ($) {
+    'use strict';
+
+    function ensureStarHelper() {
+        if (typeof window.renderStarRatingJs !== 'function') {
+            window.renderStarRatingJs = function (rating) {
+                const rounded = Math.round((rating || 0) * 2) / 2;
+                let stars = '<span class="star-rating" style="pointer-events: none; display: inline-block;">';
+                for (let i = 1; i <= 5; i += 1) {
+                    let cls;
+                    if (rounded >= i) {
+                        cls = 'fa-solid fa-star selected';
+                    } else if (rounded >= i - 0.5) {
+                        cls = 'fa-solid fa-star-half-stroke selected';
+                    } else {
+                        cls = 'fa-regular fa-star';
+                    }
+                    stars += `<i class="${cls}"></i>`;
+                }
+                return `${stars}</span>`;
+            };
+        }
+    }
+
+    function getStarRenderer() {
+        ensureStarHelper();
+        return window.renderStarRatingJs;
+    }
+
+    function hideElement($el) {
+        if ($el && $el.length) {
+            $el.addClass('d-none');
+        }
+    }
+
+    function showElement($el) {
+        if ($el && $el.length) {
+            $el.removeClass('d-none');
+        }
+    }
+
+    const summarySelectors = {
+        hosted: $('[data-summary-key="hosted"]'),
+        uniqueParticipants: $('[data-summary-key="uniqueParticipants"]'),
+        recentHost: $('[data-summary-key="recentHost"]'),
+        recentQuest: $('[data-summary-key="recentQuest"]')
+    };
+
+    function resetSummary(card) {
+        if (!card || !card.length) {
+            return;
+        }
+        hideElement(card.find('.summary-error'));
+        hideElement(card.find('.summary-rating'));
+        hideElement(card.find('.summary-value'));
+    }
+
+    function showSummaryError(key, message) {
+        const card = summarySelectors[key];
+        if (!card || !card.length) {
+            return;
+        }
+        hideElement(card.find('.summary-spinner'));
+        resetSummary(card);
+        const errorEl = card.find('.summary-error');
+        if (errorEl.length) {
+            errorEl.text(message).removeClass('d-none');
+        }
+    }
+
+    function setSummaryNumber(key, value) {
+        const card = summarySelectors[key];
+        if (!card || !card.length) {
+            return;
+        }
+        hideElement(card.find('.summary-spinner'));
+        hideElement(card.find('.summary-error'));
+        const valueEl = card.find('.summary-value');
+        if (valueEl.length) {
+            const numeric = Number.isFinite(value) ? value : null;
+            valueEl.text(numeric !== null ? numeric.toLocaleString() : '—').removeClass('d-none');
+        }
+    }
+
+    function setSummaryMessage(key, message) {
+        const card = summarySelectors[key];
+        if (!card || !card.length) {
+            return;
+        }
+        hideElement(card.find('.summary-spinner'));
+        hideElement(card.find('.summary-error'));
+        const messageEl = card.find('.summary-value');
+        if (messageEl.length) {
+            messageEl.text(message).removeClass('d-none');
+        }
+        hideElement(card.find('.summary-rating'));
+    }
+
+    function setSummaryRating(key, rating) {
+        const card = summarySelectors[key];
+        if (!card || !card.length) {
+            return;
+        }
+        hideElement(card.find('.summary-spinner'));
+        hideElement(card.find('.summary-error'));
+        const ratingEl = card.find('.summary-rating');
+        const valueEl = card.find('.summary-value');
+        if (typeof rating === 'number' && !Number.isNaN(rating) && rating > 0) {
+            if (ratingEl.length) {
+                const renderStarRating = getStarRenderer();
+                const ratingHtml = `${renderStarRating(rating)}<span class="ms-1">${rating.toFixed(2)}/5</span>`;
+                ratingEl.html(ratingHtml).removeClass('d-none');
+            }
+            hideElement(valueEl);
+        } else if (valueEl.length) {
+            valueEl.text('Not enough data yet.').removeClass('d-none');
+            hideElement(ratingEl);
+        }
+    }
+
+    function formatDateFromPayload(dateObj) {
+        if (!dateObj || typeof dateObj !== 'object') {
+            return { text: '—', tooltip: '', order: '' };
+        }
+        if (typeof dateObj.timestamp === 'number') {
+            const local = new Date(dateObj.timestamp * 1000);
+            const text = `${local.toLocaleDateString(undefined, {
+                weekday: 'short',
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+            })} ${local.toLocaleTimeString()}`;
+            const tooltip = dateObj.formattedDetailed ? `${dateObj.formattedDetailed} UTC` : '';
+            return { text, tooltip, order: dateObj.timestamp };
+        }
+        if (dateObj.formattedBasic) {
+            const tooltip = dateObj.formattedDetailed ? `${dateObj.formattedDetailed} UTC` : '';
+            return { text: dateObj.formattedBasic, tooltip, order: dateObj.formattedBasic };
+        }
+        return { text: '—', tooltip: '', order: '' };
+    }
+
+    function renderOverview(overview, errorMessage) {
+        if (!overview || typeof overview !== 'object') {
+            const message = errorMessage || 'Unable to load overview.';
+            Object.keys(summarySelectors).forEach((key) => showSummaryError(key, message));
+            return;
+        }
+        const totals = overview.totals || {};
+        const participants = overview.participants || {};
+        const ratings = overview.ratings || {};
+
+        setSummaryNumber('hosted', Number(totals.hosted));
+        setSummaryNumber('uniqueParticipants', Number(participants.unique));
+        if (ratings && Object.prototype.hasOwnProperty.call(ratings, 'recentHost')) {
+            setSummaryRating('recentHost', Number(ratings.recentHost));
+        } else {
+            setSummaryMessage('recentHost', 'Not enough data yet.');
+        }
+        if (ratings && Object.prototype.hasOwnProperty.call(ratings, 'recentQuest')) {
+            setSummaryRating('recentQuest', Number(ratings.recentQuest));
+        } else {
+            setSummaryMessage('recentQuest', 'Not enough data yet.');
+        }
+    }
+
+    function renderUpcomingList(upcoming, errorMessage) {
+        const $spinner = $('#upcomingSpinner');
+        const $error = $('#upcomingError');
+        const $empty = $('#upcomingEmpty');
+        const $list = $('#upcomingList');
+
+        hideElement($spinner);
+        hideElement($error);
+        hideElement($empty);
+        if ($list.length) {
+            $list.empty().addClass('d-none');
+        }
+
+        if (errorMessage) {
+            if ($error.length) {
+                $error.text(errorMessage).removeClass('d-none');
+            }
+            return;
+        }
+
+        if (!Array.isArray(upcoming) || upcoming.length === 0) {
+            showElement($empty);
+            return;
+        }
+
+        upcoming.forEach((quest) => {
+            const card = $('<div class="card mb-4 feed-card"></div>');
+            const row = $('<div class="row g-0 align-items-center"></div>');
+
+            const imageCol = $('<div class="col-12 col-md-4 col-lg-3 text-center p-3"></div>');
+            if (quest && quest.icon) {
+                imageCol.append($('<img>', {
+                    src: quest.icon,
+                    class: 'img-fluid rounded',
+                    alt: quest.title || 'Quest icon'
+                }));
+            } else {
+                imageCol.append('<div class="text-muted">No image</div>');
+            }
+
+            const bodyCol = $('<div class="col p-3 d-flex flex-column gap-2"></div>');
+            const title = quest && quest.title ? quest.title : 'Untitled Quest';
+            const url = quest && quest.url ? quest.url : '#';
+            const titleLink = $('<a></a>', {
+                href: url,
+                target: '_blank',
+                rel: 'noopener'
+            }).append($('<h5 class="card-title mb-1"></h5>').text(title));
+            bodyCol.append(titleLink);
+
+            if (quest && quest.description) {
+                bodyCol.append($('<p class="mb-2"></p>').text(quest.description));
+            }
+
+            if (quest && quest.dateTime) {
+                const formatted = formatDateFromPayload(quest.dateTime);
+                const meta = $('<p class="text-muted small mb-2"></p>').text(formatted.text);
+                bodyCol.append(meta);
+            }
+
+            if (quest && quest.reviewStatus) {
+                const reviewStatus = quest.reviewStatus;
+                const badgeRow = $('<div class="d-flex flex-wrap gap-2 small text-muted"></div>');
+                const parts = [];
+                if (reviewStatus.published) { parts.push(`${reviewStatus.published} published`); }
+                if (reviewStatus.beingReviewed) { parts.push(`${reviewStatus.beingReviewed} in review`); }
+                if (reviewStatus.draft) { parts.push(`${reviewStatus.draft} draft`); }
+                if (parts.length) {
+                    badgeRow.text(parts.join(' • '));
+                    bodyCol.append(badgeRow);
+                }
+            }
+
+            const actions = $('<div class="d-flex justify-content-end mt-auto"></div>');
+            if (quest && quest.questId) {
+                const cloneBtn = $('<button type="button" class="btn btn-sm btn-outline-secondary clone-quest-btn"></button>')
+                    .attr('data-quest-id', quest.questId)
+                    .attr('data-quest-title', title)
+                    .html('<i class="fa-regular fa-clone me-1"></i>Clone Quest');
+                actions.append(cloneBtn);
+            }
+            bodyCol.append(actions);
+
+            row.append(imageCol).append(bodyCol);
+            card.append(row);
+            $list.append(card);
+        });
+
+        $list.removeClass('d-none');
+    }
+
+    function initializeTooltips($container) {
+        if (!window.bootstrap || typeof window.bootstrap.Tooltip !== 'function') {
+            return;
+        }
+        $container.find('[data-bs-toggle="tooltip"]').each(function () {
+            const instance = window.bootstrap.Tooltip.getInstance(this);
+            if (instance) {
+                instance.dispose();
+            }
+            new window.bootstrap.Tooltip(this);
+        });
+    }
+
+    function renderQuestReviewsTable(rows, errorMessage) {
+        const $spinner = $('#questReviewsSpinner');
+        const $error = $('#questReviewsError');
+        const $empty = $('#questReviewsEmpty');
+        const $wrapper = $('#questReviewsTableWrapper');
+        const $table = $('#datatable-reviews');
+
+        hideElement($spinner);
+        hideElement($error);
+        hideElement($empty);
+        if ($wrapper.length) {
+            $wrapper.addClass('d-none');
+        }
+
+        if ($.fn.DataTable && $.fn.DataTable.isDataTable($table)) {
+            $table.DataTable().destroy();
+        }
+
+        const $tbody = $table.find('tbody');
+        if ($tbody.length) {
+            $tbody.empty();
+        }
+
+        if (errorMessage) {
+            if ($error.length) {
+                $error.text(errorMessage).removeClass('d-none');
+            }
+            return;
+        }
+
+        if (!Array.isArray(rows) || rows.length === 0) {
+            showElement($empty);
+            return;
+        }
+
+        const renderStarRating = getStarRenderer();
+        rows.forEach((summary) => {
+            const $row = $('<tr></tr>');
+
+            const $questCell = $('<td></td>');
+            const questWrapper = $('<div class="d-flex align-items-center"></div>');
+            if (summary.questIcon) {
+                questWrapper.append($('<img>', {
+                    src: summary.questIcon,
+                    class: 'rounded me-2',
+                    css: { width: '40px', height: '40px' },
+                    alt: summary.questTitle || 'Quest'
+                }));
+            }
+            const questLink = $('<a></a>', {
+                href: summary.questLocator ? `/q/${summary.questLocator}` : '#',
+                target: '_blank',
+                text: summary.questTitle || 'Quest'
+            });
+            questWrapper.append(questLink);
+            $questCell.append(questWrapper);
+            $row.append($questCell);
+
+            const $dateCell = $('<td></td>');
+            const formattedDate = formatDateFromPayload(summary.questEndDate);
+            if (formattedDate.order !== '') {
+                $dateCell.attr('data-order', formattedDate.order);
+            }
+            const $dateSpan = $('<span class="date"></span>').text(formattedDate.text);
+            if (formattedDate.tooltip) {
+                $dateSpan.attr('data-bs-toggle', 'tooltip')
+                    .attr('data-bs-placement', 'bottom')
+                    .attr('data-bs-title', formattedDate.tooltip);
+            }
+            $dateCell.append($dateSpan);
+            $row.append($dateCell);
+
+            const hostRating = Number(summary.avgHostRating);
+            const $hostCell = $('<td class="align-middle"></td>').attr('data-order', Number.isFinite(hostRating) ? hostRating : 0);
+            if (Number.isFinite(hostRating) && hostRating > 0) {
+                $hostCell.html(`${renderStarRating(hostRating)}<span class="ms-1">${hostRating.toFixed(2)}</span>`);
+            } else {
+                $hostCell.text('—');
+            }
+            $row.append($hostCell);
+
+            const questRating = Number(summary.avgQuestRating);
+            const $questRatingCell = $('<td class="align-middle"></td>').attr('data-order', Number.isFinite(questRating) ? questRating : 0);
+            if (Number.isFinite(questRating) && questRating > 0) {
+                $questRatingCell.html(`${renderStarRating(questRating)}<span class="ms-1">${questRating.toFixed(2)}</span>`);
+            } else {
+                $questRatingCell.text('—');
+            }
+            $row.append($questRatingCell);
+
+            const reviewsBtn = $('<button type="button" class="btn btn-sm view-reviews-btn"></button>')
+                .addClass(summary.hasComments ? 'btn-primary' : 'btn-outline-secondary')
+                .attr('data-quest-id', summary.questId || '')
+                .attr('data-quest-title', summary.questTitle || '')
+                .attr('data-quest-banner', summary.questBanner || '')
+                .html(`<i class="${summary.hasComments ? 'fa-solid' : 'fa-regular'} fa-comments me-1"></i>View`);
+            $row.append($('<td class="align-middle"></td>').append(reviewsBtn));
+
+            const cloneBtn = $('<button type="button" class="btn btn-sm btn-outline-secondary clone-quest-btn"></button>')
+                .attr('data-quest-id', summary.questId || '')
+                .attr('data-quest-title', summary.questTitle || '')
+                .html('<i class="fa-regular fa-clone me-1"></i>Clone');
+            $row.append($('<td class="align-middle"></td>').append(cloneBtn));
+
+            $tbody.append($row);
+        });
+
+        initializeTooltips($tbody);
+
+        if ($wrapper.length) {
+            $wrapper.removeClass('d-none');
+        }
+
+        if ($.fn.DataTable) {
+            $table.DataTable({
+                pageLength: 10,
+                lengthChange: true,
+                columnDefs: [{ targets: [4, 5], orderable: false }],
+                order: [[1, 'desc']]
+            });
+        }
+    }
+
+    const charts = {
+        review: null,
+        ratingOverTime: null,
+        participant: null
+    };
+
+    function destroyChart(instanceKey) {
+        if (charts[instanceKey]) {
+            charts[instanceKey].destroy();
+            charts[instanceKey] = null;
+        }
+    }
+
+    function renderReviewChart(chartData, errorMessage) {
+        const $spinner = $('#reviewChartSpinner');
+        const $error = $('#reviewChartError');
+        const $empty = $('#reviewChartEmpty');
+        const $canvas = $('#reviewChart');
+
+        hideElement($spinner);
+        hideElement($error);
+        hideElement($empty);
+        hideElement($canvas);
+
+        if (errorMessage) {
+            $error.text(errorMessage).removeClass('d-none');
+            return;
+        }
+
+        const labels = chartData && Array.isArray(chartData.questTitles) ? chartData.questTitles : [];
+        const hostRatings = chartData && Array.isArray(chartData.avgHostRatings) ? chartData.avgHostRatings : [];
+        const questRatings = chartData && Array.isArray(chartData.avgQuestRatings) ? chartData.avgQuestRatings : [];
+
+        if (!labels.length || typeof Chart === 'undefined') {
+            if (!labels.length) {
+                $empty.removeClass('d-none');
+            } else {
+                $error.text('Chart library unavailable.').removeClass('d-none');
+            }
+            return;
+        }
+
+        destroyChart('review');
+        const ctx = $canvas[0].getContext('2d');
+        charts.review = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [
+                    {
+                        label: 'Avg Host Rating',
+                        data: hostRatings,
+                        backgroundColor: 'rgba(75, 192, 192, 0.6)'
+                    },
+                    {
+                        label: 'Avg Quest Rating',
+                        data: questRatings,
+                        backgroundColor: 'rgba(153, 102, 255, 0.6)'
+                    }
+                ]
+            },
+            options: {
+                scales: {
+                    yAxes: [{
+                        ticks: {
+                            beginAtZero: true,
+                            max: 5
+                        }
+                    }]
+                }
+            }
+        });
+        showElement($canvas);
+    }
+
+    function renderRatingOverTimeChart(chartData, errorMessage) {
+        const $spinner = $('#ratingOverTimeChartSpinner');
+        const $error = $('#ratingOverTimeChartError');
+        const $empty = $('#ratingOverTimeChartEmpty');
+        const $canvas = $('#ratingOverTimeChart');
+
+        hideElement($spinner);
+        hideElement($error);
+        hideElement($empty);
+        hideElement($canvas);
+
+        if (errorMessage) {
+            $error.text(errorMessage).removeClass('d-none');
+            return;
+        }
+
+        const labels = chartData && Array.isArray(chartData.ratingDates) ? chartData.ratingDates : [];
+        const averages = chartData && Array.isArray(chartData.avgRatingsOverTime) ? chartData.avgRatingsOverTime : [];
+
+        if (!labels.length || typeof Chart === 'undefined') {
+            if (!labels.length) {
+                $empty.removeClass('d-none');
+            } else {
+                $error.text('Chart library unavailable.').removeClass('d-none');
+            }
+            return;
+        }
+
+        destroyChart('ratingOverTime');
+        const ctx = $canvas[0].getContext('2d');
+        charts.ratingOverTime = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels,
+                datasets: [{
+                    label: 'Avg Quest Rating',
+                    data: averages,
+                    fill: false,
+                    borderColor: 'rgba(255, 206, 86, 1)',
+                    tension: 0.1
+                }]
+            },
+            options: {
+                scales: {
+                    xAxes: [{
+                        type: 'time',
+                        time: {
+                            parser: 'YYYY-MM-DD',
+                            unit: 'day',
+                            displayFormats: {
+                                day: 'MMM D'
+                            }
+                        }
+                    }],
+                    yAxes: [{
+                        ticks: {
+                            beginAtZero: true,
+                            max: 5
+                        }
+                    }]
+                }
+            }
+        });
+        showElement($canvas);
+    }
+
+    function renderParticipantChart(chartData, errorMessage) {
+        const $spinner = $('#participantPerQuestChartSpinner');
+        const $error = $('#participantPerQuestChartError');
+        const $empty = $('#participantPerQuestChartEmpty');
+        const $canvas = $('#participantPerQuestChart');
+
+        hideElement($spinner);
+        hideElement($error);
+        hideElement($empty);
+        hideElement($canvas);
+
+        if (errorMessage) {
+            $error.text(errorMessage).removeClass('d-none');
+            return;
+        }
+
+        const labels = chartData && Array.isArray(chartData.participantQuestTitles) ? chartData.participantQuestTitles : [];
+        const counts = chartData && Array.isArray(chartData.participantCounts) ? chartData.participantCounts : [];
+
+        if (!labels.length || typeof Chart === 'undefined') {
+            if (!labels.length) {
+                $empty.removeClass('d-none');
+            } else {
+                $error.text('Chart library unavailable.').removeClass('d-none');
+            }
+            return;
+        }
+
+        destroyChart('participant');
+        const ctx = $canvas[0].getContext('2d');
+        charts.participant = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [{
+                    label: 'Participants',
+                    data: counts,
+                    backgroundColor: 'rgba(54, 162, 235, 0.6)'
+                }]
+            },
+            options: {
+                scales: {
+                    yAxes: [{
+                        ticks: {
+                            beginAtZero: true,
+                            precision: 0
+                        }
+                    }]
+                }
+            }
+        });
+        showElement($canvas);
+    }
+
+    function renderCharts(chartData, errorMessage) {
+        renderReviewChart(chartData, errorMessage);
+        renderRatingOverTimeChart(chartData, errorMessage);
+        renderParticipantChart(chartData, errorMessage);
+    }
+
+    function handleError(message) {
+        const errorMessage = message || 'Unable to load dashboard data. Please try again later.';
+        renderOverview(null, errorMessage);
+        renderUpcomingList(null, errorMessage);
+        renderQuestReviewsTable(null, errorMessage);
+        renderCharts(null, errorMessage);
+    }
+
+    function loadDashboard(sessionToken) {
+        if (!sessionToken) {
+            handleError('Session expired. Please log in again.');
+            return;
+        }
+
+        $.ajax({
+            url: '/api/v1/quest/dashboard.php',
+            method: 'POST',
+            dataType: 'json',
+            data: { sessionToken }
+        }).done((resp) => {
+            if (resp && resp.success && resp.data) {
+                renderOverview(resp.data.overview || null);
+                renderUpcomingList(resp.data.upcoming || []);
+                const reviewPayload = resp.data.reviews || {};
+                renderQuestReviewsTable(reviewPayload.summaries || []);
+                renderCharts(reviewPayload.chart || {});
+            } else {
+                handleError(resp && resp.message ? resp.message : null);
+            }
+        }).fail(() => {
+            handleError('Unable to load dashboard data. Please check your connection and try again.');
+        });
+    }
+
+    $(function () {
+        ensureStarHelper();
+        const config = window.questDashboardConfig || {};
+        loadDashboard(config.sessionToken || '');
+    });
+})(jQuery);

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -117,33 +117,59 @@ function renderStarRating(float $rating): string
     <div class="row text-center g-3 mt-3 mb-3">
         <div class="col-12 col-md-3">
             <div class="card h-100">
-                <div class="card-body">
+                <div class="card-body summary-card" data-summary-key="hosted">
                     <small>Total Quests Hosted</small>
-                    <h3 class="mb-0"><?= $totalHostedQuests; ?></h3>
+                    <div class="summary-spinner text-center py-2">
+                        <div class="spinner-border spinner-border-sm text-secondary" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+                    <div class="summary-error alert alert-danger d-none mt-2" role="alert"></div>
+                    <h3 class="summary-value mb-0 d-none"></h3>
                 </div>
             </div>
         </div>
         <div class="col-12 col-md-3">
             <div class="card h-100">
-                <div class="card-body">
+                <div class="card-body summary-card" data-summary-key="uniqueParticipants">
                     <small>Total Unique Participants</small>
-                    <h3 class="mb-0"><?= $totalUniqueParticipants; ?></h3>
+                    <div class="summary-spinner text-center py-2">
+                        <div class="spinner-border spinner-border-sm text-secondary" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+                    <div class="summary-error alert alert-danger d-none mt-2" role="alert"></div>
+                    <h3 class="summary-value mb-0 d-none"></h3>
                 </div>
             </div>
         </div>
         <div class="col-12 col-md-3">
             <div class="card h-100">
-                <div class="card-body">
+                <div class="card-body summary-card" data-summary-key="recentHost">
                     <small>Average Host Rating (Last 10)</small>
-                    <div><?= renderStarRating($avgHostRatingRecent); ?><span class="ms-1"><?= number_format($avgHostRatingRecent, 2); ?>/5</span></div>
+                    <div class="summary-spinner text-center py-2">
+                        <div class="spinner-border spinner-border-sm text-secondary" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+                    <div class="summary-error alert alert-danger d-none mt-2" role="alert"></div>
+                    <div class="summary-rating d-none"></div>
+                    <div class="summary-value text-muted d-none"></div>
                 </div>
             </div>
         </div>
         <div class="col-12 col-md-3">
             <div class="card h-100">
-                <div class="card-body">
+                <div class="card-body summary-card" data-summary-key="recentQuest">
                     <small>Average Quest Rating (Last 10)</small>
-                    <div><?= renderStarRating($avgQuestRatingRecent); ?><span class="ms-1"><?= number_format($avgQuestRatingRecent, 2); ?>/5</span></div>
+                    <div class="summary-spinner text-center py-2">
+                        <div class="spinner-border spinner-border-sm text-secondary" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+                    <div class="summary-error alert alert-danger d-none mt-2" role="alert"></div>
+                    <div class="summary-rating d-none"></div>
+                    <div class="summary-value text-muted d-none"></div>
                 </div>
             </div>
         </div>
@@ -165,21 +191,16 @@ function renderStarRating(float $rating): string
             <div class="tab-content" id="nav-tabContent">
                 <div class="tab-pane fade show active" id="nav-upcoming" role="tabpanel" aria-labelledby="nav-upcoming-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Upcoming Quests</div>
-                    <?php if (count($futureQuests) === 0) { ?>
-                        <p>No upcoming quests.</p>
-                    <?php } else { foreach ($futureQuests as $quest) { ?>
-                        <div class="mb-4">
-                            <?php
-                                $_vFeedCard = FeedCardController::vQuest_to_vFeedCard($quest);
-                                require("php-components/vFeedCardRenderer.php");
-                            ?>
-                            <div class="text-end">
-                                <button class="btn btn-sm btn-outline-secondary clone-quest-btn" data-quest-id="<?= $quest->crand; ?>" data-quest-title="<?= htmlspecialchars($quest->title); ?>">
-                                    <i class="fa-regular fa-clone me-1"></i>Clone Quest
-                                </button>
+                    <div id="upcomingSection">
+                        <div id="upcomingSpinner" class="section-spinner text-center py-3">
+                            <div class="spinner-border text-secondary" role="status">
+                                <span class="visually-hidden">Loading...</span>
                             </div>
                         </div>
-                    <?php }} ?>
+                        <div id="upcomingError" class="alert alert-danger d-none" role="alert"></div>
+                        <p id="upcomingEmpty" class="text-muted d-none">No upcoming quests.</p>
+                        <div id="upcomingList" class="d-none"></div>
+                    </div>
                 </div>
                 <div class="tab-pane fade" id="nav-review-inbox" role="tabpanel" aria-labelledby="nav-review-inbox-tab" tabindex="0">
                     <div class="d-flex flex-column flex-sm-row align-items-sm-center justify-content-between gap-2 mb-3">
@@ -202,10 +223,15 @@ function renderStarRating(float $rating): string
                 </div>
                 <div class="tab-pane fade" id="nav-reviews" role="tabpanel" aria-labelledby="nav-reviews-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Quest Reviews</div>
-                    <?php if (count($questReviewAverages) === 0) { ?>
-                        <p>No quest reviews yet.</p>
-                    <?php } else { ?>
-                        <div class="table-responsive">
+                    <div id="questReviewsSection">
+                        <div id="questReviewsSpinner" class="section-spinner text-center py-3">
+                            <div class="spinner-border text-secondary" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                            </div>
+                        </div>
+                        <div id="questReviewsError" class="alert alert-danger d-none" role="alert"></div>
+                        <p id="questReviewsEmpty" class="text-muted d-none">No quest reviews yet.</p>
+                        <div id="questReviewsTableWrapper" class="table-responsive d-none">
                             <table id="datatable-reviews" class="table table-striped">
                                 <thead>
                                     <tr>
@@ -217,39 +243,10 @@ function renderStarRating(float $rating): string
                                         <th>Clone</th>
                                     </tr>
                                 </thead>
-                                <tbody>
-                                    <?php foreach ($questReviewAverages as $qr) { ?>
-                                        <tr>
-                                            <td>
-                                                <div class="d-flex align-items-center">
-                                                    <img src="<?= htmlspecialchars($qr->questIcon); ?>" class="rounded me-2" style="width:40px;height:40px;" alt="">
-                                                    <a href="<?= htmlspecialchars(Version::formatUrl('/q/' . $qr->questLocator)); ?>" target="_blank"><?= htmlspecialchars($qr->questTitle); ?></a>
-                                                </div>
-                                            </td>
-                                            <?php $qd = new vDateTime($qr->questEndDate); ?>
-                                            <td data-order="<?= htmlspecialchars($qd->dbValue); ?>">
-                                                <span class="date" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="<?= htmlspecialchars($qd->formattedDetailed); ?> UTC" data-datetime-utc="<?= htmlspecialchars($qd->valueString); ?>" data-db-value="<?= htmlspecialchars($qd->dbValue); ?>"><?= htmlspecialchars($qd->formattedBasic); ?></span>
-                                            </td>
-                                            <td data-order="<?= $qr->avgHostRating; ?>" class="align-middle">
-                                                <?= renderStarRating($qr->avgHostRating); ?><span class="ms-1"><?= number_format($qr->avgHostRating, 2); ?></span>
-                                            </td>
-                                            <td data-order="<?= $qr->avgQuestRating; ?>" class="align-middle">
-                                                <?= renderStarRating($qr->avgQuestRating); ?><span class="ms-1"><?= number_format($qr->avgQuestRating, 2); ?></span>
-                                            </td>
-                                            <td class="align-middle">
-                                                <?php $btnClass = !empty($qr->hasComments) ? 'btn-primary' : 'btn-outline-secondary'; ?>
-                                                <?php $iconClass = !empty($qr->hasComments) ? 'fa-solid' : 'fa-regular'; ?>
-                                                <button class="btn btn-sm <?= $btnClass ?> view-reviews-btn" data-quest-id="<?= $qr->questId; ?>" data-quest-title="<?= htmlspecialchars($qr->questTitle); ?>" data-quest-banner="<?= htmlspecialchars($qr->questBanner); ?>"><i class="<?= $iconClass ?> fa-comments me-1"></i>View</button>
-                                            </td>
-                                            <td class="align-middle">
-                                                <button class="btn btn-sm btn-outline-secondary clone-quest-btn" data-quest-id="<?= $qr->questId; ?>" data-quest-title="<?= htmlspecialchars($qr->questTitle); ?>"><i class="fa-regular fa-clone me-1"></i>Clone</button>
-                                            </td>
-                                        </tr>
-                                    <?php } ?>
-                                </tbody>
+                                <tbody></tbody>
                             </table>
                         </div>
-                    <?php } ?>
+                    </div>
                 </div>
                 <div class="tab-pane fade" id="nav-graphs" role="tabpanel" aria-labelledby="nav-graphs-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Quest Analytics</div>
@@ -262,7 +259,14 @@ function renderStarRating(float $rating): string
                             </h2>
                             <div id="collapseRatings" class="accordion-collapse collapse show" aria-labelledby="headingRatings">
                                 <div class="accordion-body">
-                                    <canvas id="reviewChart"></canvas>
+                                    <div id="reviewChartSpinner" class="section-spinner text-center py-3">
+                                        <div class="spinner-border text-secondary" role="status">
+                                            <span class="visually-hidden">Loading...</span>
+                                        </div>
+                                    </div>
+                                    <div id="reviewChartError" class="alert alert-danger d-none" role="alert"></div>
+                                    <p id="reviewChartEmpty" class="text-muted d-none mb-0">Not enough data to render this chart.</p>
+                                    <canvas id="reviewChart" class="d-none"></canvas>
                                 </div>
                             </div>
                         </div>
@@ -274,7 +278,14 @@ function renderStarRating(float $rating): string
                             </h2>
                             <div id="collapseRatingOverTime" class="accordion-collapse collapse" aria-labelledby="headingRatingOverTime">
                                 <div class="accordion-body">
-                                    <canvas id="ratingOverTimeChart"></canvas>
+                                    <div id="ratingOverTimeChartSpinner" class="section-spinner text-center py-3">
+                                        <div class="spinner-border text-secondary" role="status">
+                                            <span class="visually-hidden">Loading...</span>
+                                        </div>
+                                    </div>
+                                    <div id="ratingOverTimeChartError" class="alert alert-danger d-none" role="alert"></div>
+                                    <p id="ratingOverTimeChartEmpty" class="text-muted d-none mb-0">Not enough data to render this chart.</p>
+                                    <canvas id="ratingOverTimeChart" class="d-none"></canvas>
                                 </div>
                             </div>
                         </div>
@@ -286,7 +297,14 @@ function renderStarRating(float $rating): string
                             </h2>
                             <div id="collapsePerQuest" class="accordion-collapse collapse" aria-labelledby="headingPerQuest">
                                 <div class="accordion-body">
-                                    <canvas id="participantPerQuestChart"></canvas>
+                                    <div id="participantPerQuestChartSpinner" class="section-spinner text-center py-3">
+                                        <div class="spinner-border text-secondary" role="status">
+                                            <span class="visually-hidden">Loading...</span>
+                                        </div>
+                                    </div>
+                                    <div id="participantPerQuestChartError" class="alert alert-danger d-none" role="alert"></div>
+                                    <p id="participantPerQuestChartEmpty" class="text-muted d-none mb-0">Not enough data to render this chart.</p>
+                                    <canvas id="participantPerQuestChart" class="d-none"></canvas>
                                 </div>
                             </div>
                         </div>
@@ -911,34 +929,17 @@ function renderStarRating(float $rating): string
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js"></script>
 <script>
-const questTitles = <?= json_encode($questTitles); ?>;
-const avgHostRatings = <?= json_encode($avgHostRatings); ?>;
-const avgQuestRatings = <?= json_encode($avgQuestRatings); ?>;
-const participantCounts = <?= json_encode($participantCounts); ?>;
-const participantQuestTitles = <?= json_encode($participantQuestTitles); ?>;
-const ratingDates = <?= json_encode($ratingDates); ?>;
-const avgRatingsOverTime = <?= json_encode($avgRatingsOverTime); ?>;
-
-function renderStarRatingJs(rating) {
-    const rounded = Math.round(rating * 2) / 2;
-    let stars = '<span class="star-rating" style="pointer-events: none; display: inline-block;">';
-    for (let i = 1; i <= 5; i++) {
-        let cls;
-        if (rounded >= i) {
-            cls = 'fa-solid fa-star selected';
-        } else if (rounded >= i - 0.5) {
-            cls = 'fa-solid fa-star-half-stroke selected';
-        } else {
-            cls = 'fa-regular fa-star';
-        }
-        stars += `<i class="${cls}"></i>`;
-    }
-    return stars + '</span>';
-}
-
+window.questDashboardConfig = Object.assign({}, window.questDashboardConfig || {}, {
+    sessionToken: "<?= $_SESSION['sessionToken']; ?>",
+    currentHostId: <?= $account->crand; ?>
+});
+</script>
+<script src="<?= Version::urlBetaPrefix(); ?>/assets/js/questGiverDashboard.js"></script>
+<script>
 $(document).ready(function () {
-    const sessionToken = "<?= $_SESSION['sessionToken']; ?>";
-    const currentHostId = <?= $account->crand; ?>;
+    const config = window.questDashboardConfig || {};
+    const sessionToken = config.sessionToken || '';
+    const currentHostId = config.currentHostId || 0;
 
     let globalParticipationCounts = {};
     let personalParticipationCounts = {};
@@ -1350,13 +1351,6 @@ $(document).ready(function () {
         }, 'json');
     }
 
-    $('#datatable-reviews').DataTable({
-        pageLength: 10,
-        lengthChange: true,
-        columnDefs: [{ targets: [4, 5], orderable: false }],
-        order: [[1, 'desc']]
-    });
-
     function escapeHtml(str) {
         return $('<div>').text(str ?? '').html();
     }
@@ -1522,93 +1516,6 @@ $(document).ready(function () {
                 $('#reviewModalBody').html('<div class="text-danger">' + resp.message + '</div>');
             }
         }, 'json');
-    });
-    var reviewCtx = document.getElementById('reviewChart').getContext('2d');
-    new Chart(reviewCtx, {
-        type: 'bar',
-        data: {
-            labels: questTitles,
-            datasets: [
-                {
-                    label: 'Avg Host Rating',
-                    data: avgHostRatings,
-                    backgroundColor: 'rgba(75, 192, 192, 0.6)'
-                },
-                {
-                    label: 'Avg Quest Rating',
-                    data: avgQuestRatings,
-                    backgroundColor: 'rgba(153, 102, 255, 0.6)'
-                }
-            ]
-        },
-        options: {
-            scales: {
-                yAxes: [{
-                    ticks: {
-                        beginAtZero: true,
-                        max: 5
-                    }
-                }]
-            }
-        }
-    });
-
-    var ratingOverTimeCtx = document.getElementById('ratingOverTimeChart').getContext('2d');
-    new Chart(ratingOverTimeCtx, {
-        type: 'line',
-        data: {
-            labels: ratingDates,
-            datasets: [{
-                label: 'Avg Quest Rating',
-                data: avgRatingsOverTime,
-                fill: false,
-                borderColor: 'rgba(255, 206, 86, 1)',
-                tension: 0.1
-            }]
-        },
-        options: {
-            scales: {
-                xAxes: [{
-                    type: 'time',
-                    time: {
-                        parser: 'YYYY-MM-DD',
-                        unit: 'day',
-                        displayFormats: {
-                            day: 'MMM D'
-                        }
-                    }
-                }],
-                yAxes: [{
-                    ticks: {
-                        beginAtZero: true,
-                        max: 5
-                    }
-                }]
-            }
-        }
-    });
-
-    var perQuestCtx = document.getElementById('participantPerQuestChart').getContext('2d');
-    new Chart(perQuestCtx, {
-        type: 'bar',
-        data: {
-            labels: participantQuestTitles,
-            datasets: [{
-                label: 'Participants',
-                data: participantCounts,
-                backgroundColor: 'rgba(54, 162, 235, 0.6)'
-            }]
-        },
-        options: {
-            scales: {
-                yAxes: [{
-                    ticks: {
-                        beginAtZero: true,
-                        precision: 0
-                    }
-                }]
-            }
-        }
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- add a dedicated questGiverDashboard.js module that pulls quest dashboard data via the new API and rebuilds the overview cards, upcoming quests, reviews, and charts in JavaScript
- update quest-giver-dashboard.php to provide loading placeholders, surface errors per section, and include the new module while keeping existing interactive flows intact
- expose quest identifiers and formatted review dates in the quest dashboard API payload for the new front-end rendering flow

## Testing
- php -l html/quest-giver-dashboard.php
- php -l html/Kickback/Backend/Services/QuestDashboardService.php

------
https://chatgpt.com/codex/tasks/task_b_68cf0d976090833395cc407ca53391b5