### PR TITLE
Add dynamic dashboard rendering helpers

### DIFF
--- a/html/assets/js/questGiverDashboard.js
+++ b/html/assets/js/questGiverDashboard.js
@@ -46,6 +46,69 @@
         recentQuest: $('[data-summary-key="recentQuest"]')
     };
 
+    const sectionConfig = {
+        suggestions: {
+            spinner: '#suggestionsSpinner',
+            error: '#suggestionsError',
+            empty: '#suggestionsEmpty',
+            content: '#suggestionsContent'
+        },
+        questLines: {
+            spinner: '#questLinesSpinner',
+            error: '#questLinesError',
+            empty: '#questLinesEmpty',
+            content: '#questLinesContent'
+        },
+        top: {
+            spinner: '#topSpinner',
+            error: '#topError',
+            content: '#topContent'
+        }
+    };
+
+    function renderSectionState(sectionKey, state, message) {
+        const config = sectionConfig[sectionKey];
+        if (!config) {
+            return;
+        }
+        const $spinner = config.spinner ? $(config.spinner) : null;
+        const $error = config.error ? $(config.error) : null;
+        const $empty = config.empty ? $(config.empty) : null;
+        const $content = config.content ? $(config.content) : null;
+
+        if ($spinner && $spinner.length) {
+            if (state === 'loading') {
+                showElement($spinner);
+            } else {
+                hideElement($spinner);
+            }
+        }
+
+        if ($error && $error.length) {
+            if (state === 'error') {
+                $error.text(message || 'Unable to load data.').removeClass('d-none');
+            } else {
+                $error.addClass('d-none').text('');
+            }
+        }
+
+        if ($empty && $empty.length) {
+            if (state === 'empty') {
+                showElement($empty);
+            } else {
+                hideElement($empty);
+            }
+        }
+
+        if ($content && $content.length) {
+            if (state === 'ready') {
+                showElement($content);
+            } else {
+                hideElement($content);
+            }
+        }
+    }
+
     function resetSummary(card) {
         if (!card || !card.length) {
             return;
@@ -253,6 +316,667 @@
         });
 
         $list.removeClass('d-none');
+    }
+
+    const suggestionDefinitions = [
+        { key: 'dormantQuest', headline: 'Revive this beloved quest with a fresh twist' },
+        { key: 'fanFavoriteQuest', headline: 'Reward loyal players with a long-awaited sequel' },
+        { key: 'recommendedQuest', headline: 'Launch a new quest inspired by your top performer' },
+        { key: 'hiddenGemQuest', headline: 'Promote this hidden gem to boost attendance' },
+        { key: 'underperformingQuest', headline: 'Refine this quest to improve its performance' }
+    ];
+
+    function resolveQuestUrl(quest) {
+        if (!quest || typeof quest !== 'object') {
+            return '#';
+        }
+        if (quest.url) {
+            return quest.url;
+        }
+        if (quest.locator) {
+            return `/q/${quest.locator}`;
+        }
+        if (quest.questLocator) {
+            return `/q/${quest.questLocator}`;
+        }
+        return '#';
+    }
+
+    function resolveQuestRunInfo(quest) {
+        if (!quest || typeof quest !== 'object') {
+            return { text: 'date TBD', tooltip: '', order: '' };
+        }
+        let payload = null;
+        if (quest.lastRun && typeof quest.lastRun === 'object') {
+            payload = quest.lastRun;
+        } else if (quest.endDate && typeof quest.endDate === 'object') {
+            payload = quest.endDate;
+        } else if (quest.dateTime && typeof quest.dateTime === 'object') {
+            payload = quest.dateTime;
+        }
+        if (payload) {
+            const formatted = formatDateFromPayload(payload);
+            if (!formatted.text || formatted.text === '—') {
+                formatted.text = 'date TBD';
+            }
+            return formatted;
+        }
+        if (typeof quest.endDateFormatted === 'string' && quest.endDateFormatted) {
+            return { text: quest.endDateFormatted, tooltip: '', order: '' };
+        }
+        if (typeof quest.lastRunFormatted === 'string' && quest.lastRunFormatted) {
+            return { text: quest.lastRunFormatted, tooltip: '', order: '' };
+        }
+        return { text: 'date TBD', tooltip: '', order: '' };
+    }
+
+    function buildSuggestionCard(definition, quest, renderStarRating) {
+        const card = $('<div class="card mb-3 suggestion-card"></div>');
+        const $body = $('<div class="card-body"></div>');
+        const $header = $('<div class="d-flex align-items-center mb-2"></div>');
+        if (quest.icon) {
+            $header.append($('<img>', {
+                src: quest.icon,
+                class: 'rounded me-3',
+                css: { width: '60px', height: '60px', objectFit: 'cover' },
+                alt: quest.title || 'Quest icon'
+            }));
+        }
+        const $headerText = $('<div></div>');
+        const heading = quest.headline || definition.headline;
+        if (heading) {
+            $headerText.append($('<h5 class="card-title mb-1"></h5>').text(heading));
+        }
+
+        const questTitle = quest.title || 'Untitled Quest';
+        const questUrl = resolveQuestUrl(quest);
+        const runInfo = resolveQuestRunInfo(quest);
+        const $runLine = $('<p class="card-text mb-1"></p>');
+        const $runLink = $('<a></a>', {
+            href: questUrl,
+            target: '_blank',
+            rel: 'noopener',
+            text: questTitle
+        });
+        const $runSpan = $('<span></span>').text(runInfo.text || 'date TBD');
+        if (runInfo.tooltip) {
+            $runSpan.attr('data-bs-toggle', 'tooltip')
+                .attr('data-bs-placement', 'bottom')
+                .attr('data-bs-title', runInfo.tooltip);
+        }
+        $runLine.append($runLink).append(' last ran ').append($runSpan);
+        $headerText.append($runLine);
+
+        const ratingPieces = [];
+        const questRating = Number(quest.avgQuestRating);
+        if (Number.isFinite(questRating) && questRating > 0) {
+            ratingPieces.push(`Quest Rating: ${renderStarRating(questRating)}<span class="ms-1">${questRating.toFixed(2)}</span>`);
+        } else {
+            ratingPieces.push('Quest Rating: —');
+        }
+        const hostRating = Number(quest.avgHostRating);
+        if (Number.isFinite(hostRating) && hostRating > 0) {
+            ratingPieces.push(`Host Rating: ${renderStarRating(hostRating)}<span class="ms-1">${hostRating.toFixed(2)}</span>`);
+        } else {
+            ratingPieces.push('Host Rating: —');
+        }
+        $headerText.append($('<p class="card-text mb-0"></p>').html(ratingPieces.join(' &middot; ')));
+        $header.append($headerText);
+        $body.append($header);
+
+        if (quest.message) {
+            $body.append($('<p class="card-text mb-2"></p>').text(quest.message));
+        }
+
+        const questId = quest.id || quest.questId;
+        if (questId) {
+            const $actions = $('<div class="mt-2 d-flex flex-wrap gap-2"></div>');
+            const banner = quest.banner || quest.questBanner || '';
+            $actions.append($('<button type="button" class="btn btn-sm btn-outline-primary view-reviews-btn"></button>')
+                .attr('data-quest-id', questId)
+                .attr('data-quest-title', questTitle)
+                .attr('data-quest-banner', banner)
+                .html('<i class="fa-regular fa-comments me-1"></i>Reviews'));
+            $actions.append($('<button type="button" class="btn btn-sm btn-outline-secondary clone-quest-btn"></button>')
+                .attr('data-quest-id', questId)
+                .attr('data-quest-title', questTitle)
+                .html('<i class="fa-regular fa-clone me-1"></i>Clone Quest'));
+            $body.append($actions);
+        }
+
+        card.append($body);
+        return card;
+    }
+
+    function renderSuggestions(suggestions, errorMessage) {
+        const $cardsContainer = $('#suggestionCards');
+        const $coHostCard = $('#coHostSuggestionCard');
+        const $coHostTableBody = $('#coHostSuggestionTable tbody');
+        if ($cardsContainer.length) {
+            $cardsContainer.empty();
+        }
+        if ($coHostTableBody.length) {
+            $coHostTableBody.empty();
+        }
+        hideElement($coHostCard);
+
+        if (errorMessage) {
+            renderSectionState('suggestions', 'error', errorMessage);
+            return;
+        }
+
+        if (!suggestions || typeof suggestions !== 'object') {
+            renderSectionState('suggestions', 'empty');
+            return;
+        }
+
+        const renderStarRating = getStarRenderer();
+        let cardCount = 0;
+        suggestionDefinitions.forEach((definition) => {
+            const quest = suggestions[definition.key];
+            if (quest) {
+                $cardsContainer.append(buildSuggestionCard(definition, quest, renderStarRating));
+                cardCount += 1;
+            }
+        });
+
+        const coHosts = Array.isArray(suggestions.coHostCandidates) ? suggestions.coHostCandidates : [];
+        if ($coHostCard.length && coHosts.length > 0) {
+            coHosts.forEach((candidate) => {
+                const $row = $('<tr></tr>');
+                const $playerCell = $('<td></td>');
+                const $playerWrap = $('<div class="d-flex align-items-center"></div>');
+                if (candidate.avatar) {
+                    $playerWrap.append($('<img>', {
+                        src: candidate.avatar,
+                        class: 'rounded me-2',
+                        css: { width: '40px', height: '40px', objectFit: 'cover' },
+                        alt: candidate.username || 'Co-host'
+                    }));
+                }
+                const $playerLink = $('<a></a>', {
+                    href: candidate.url || '#',
+                    target: '_blank',
+                    rel: 'noopener',
+                    class: 'username',
+                    text: candidate.username || 'Player'
+                });
+                $playerWrap.append($playerLink);
+                $playerCell.append($playerWrap);
+                $row.append($playerCell);
+
+                const loyalty = Number(candidate.loyalty);
+                $row.append($('<td class="align-middle"></td>').text(Number.isFinite(loyalty) ? loyalty.toLocaleString() : '—'));
+
+                const reliability = Number(candidate.reliability);
+                const reliabilityText = Number.isFinite(reliability) ? `${Math.round(reliability * 100)}%` : '—';
+                $row.append($('<td class="align-middle"></td>').text(reliabilityText));
+
+                const hosted = Number(candidate.questsHosted);
+                $row.append($('<td class="align-middle"></td>').text(Number.isFinite(hosted) ? hosted.toLocaleString() : '—'));
+
+                const network = Number(candidate.network);
+                $row.append($('<td class="align-middle"></td>').text(Number.isFinite(network) ? network.toLocaleString() : '—'));
+
+                const $lastQuestCell = $('<td class="align-middle"></td>');
+                if (typeof candidate.daysSinceLastQuest === 'number') {
+                    const days = candidate.daysSinceLastQuest;
+                    $lastQuestCell.text(`${days} day${days === 1 ? '' : 's'} ago`);
+                } else if (candidate.lastQuest && typeof candidate.lastQuest === 'object') {
+                    const lastInfo = formatDateFromPayload(candidate.lastQuest);
+                    const $lastSpan = $('<span></span>').text(lastInfo.text || '—');
+                    if (lastInfo.tooltip) {
+                        $lastSpan.attr('data-bs-toggle', 'tooltip')
+                            .attr('data-bs-placement', 'bottom')
+                            .attr('data-bs-title', lastInfo.tooltip);
+                    }
+                    $lastQuestCell.append($lastSpan);
+                } else {
+                    $lastQuestCell.text('—');
+                }
+                $row.append($lastQuestCell);
+
+                $coHostTableBody.append($row);
+            });
+            showElement($coHostCard);
+        }
+
+        if (cardCount === 0 && coHosts.length === 0) {
+            renderSectionState('suggestions', 'empty');
+        } else {
+            renderSectionState('suggestions', 'ready');
+        }
+
+        initializeTooltips($cardsContainer);
+        initializeTooltips($coHostCard);
+    }
+
+    function renderQuestLines(questLines, errorMessage) {
+        const $tbody = $('#questLinesTableBody');
+        const $alert = $('#questLinesSchedulingAlert');
+        if ($tbody.length) {
+            $tbody.empty();
+        }
+        if ($alert.length) {
+            $alert.addClass('d-none').text('');
+        }
+
+        if (errorMessage) {
+            renderSectionState('questLines', 'error', errorMessage);
+            return;
+        }
+
+        if (!questLines || typeof questLines !== 'object') {
+            renderSectionState('questLines', 'empty');
+            return;
+        }
+
+        const statusCounts = questLines.statusCounts || {};
+        const setCount = (key, value) => {
+            const $el = $(`[data-quest-line-count="${key}"]`);
+            if (!$el.length) {
+                return;
+            }
+            const numeric = Number(value);
+            if (Number.isFinite(numeric)) {
+                $el.text(numeric.toLocaleString());
+            } else {
+                $el.text('—');
+            }
+        };
+        ['total', 'withUpcoming', 'withoutQuests', 'published', 'needingScheduling', 'inReview', 'draft'].forEach((key) => {
+            setCount(key, statusCounts[key]);
+        });
+
+        if (questLines.error) {
+            renderSectionState('questLines', 'error', questLines.error);
+            return;
+        }
+
+        const lines = Array.isArray(questLines.lines) ? questLines.lines : [];
+        if (!lines.length) {
+            renderSectionState('questLines', 'empty');
+            return;
+        }
+
+        const renderStarRating = getStarRenderer();
+        lines.forEach((line) => {
+            const reviewStatus = line.reviewStatus || {};
+            const counts = line.counts || {};
+            const questCount = Number(counts.quests) || 0;
+            const futureCount = Number(counts.future) || 0;
+            const pastCount = Number(counts.past) || 0;
+            const isPublished = !!reviewStatus.published;
+            const hasUpcoming = futureCount > 0;
+            const needsScheduling = isPublished && questCount > 0 && futureCount === 0;
+            const noQuestsYet = questCount === 0;
+            const statusLabel = reviewStatus.published ? 'Published' : (reviewStatus.beingReviewed ? 'In Review' : 'Draft');
+            const statusClass = reviewStatus.published ? 'bg-success' : (reviewStatus.beingReviewed ? 'bg-warning text-dark' : 'bg-secondary');
+
+            const $row = $('<tr></tr>');
+
+            const $titleCell = $('<td></td>');
+            const $titleWrap = $('<div class="d-flex align-items-center"></div>');
+            if (line.icon) {
+                $titleWrap.append($('<img>', {
+                    src: line.icon,
+                    class: 'rounded me-2',
+                    css: { width: '48px', height: '48px', objectFit: 'cover' },
+                    alt: line.title || 'Quest line icon'
+                }));
+            }
+            const $titleInfo = $('<div></div>');
+            $titleInfo.append($('<div class="fw-semibold"></div>').text(line.title || 'Quest Line'));
+            const $badgeRow = $('<div class="small"></div>');
+            $badgeRow.append(`<span class="badge ${statusClass} me-1">${statusLabel}</span>`);
+            if (hasUpcoming) {
+                $badgeRow.append('<span class="badge bg-info text-dark me-1">Upcoming quests</span>');
+            }
+            if (needsScheduling) {
+                $badgeRow.append('<span class="badge bg-warning text-dark me-1">Needs scheduling</span>');
+            }
+            if (noQuestsYet) {
+                $badgeRow.append('<span class="badge bg-secondary me-1">No quests yet</span>');
+            }
+            $titleInfo.append($badgeRow);
+            $titleWrap.append($titleInfo);
+            $titleCell.append($titleWrap);
+            $row.append($titleCell);
+
+            const $questCounts = $('<td></td>');
+            $questCounts.append($('<div class="fw-semibold"></div>').text(questCount.toLocaleString()));
+            $questCounts.append($('<div class="small text-muted"></div>').text(`${futureCount.toLocaleString()} upcoming · ${pastCount.toLocaleString()} past`));
+            const publishedCount = Number(counts.published) || 0;
+            const inReviewCount = Number(counts.inReview) || 0;
+            const draftCount = Number(counts.draft) || 0;
+            $questCounts.append($('<div class="small text-muted"></div>').text(`Published: ${publishedCount.toLocaleString()} · Review: ${inReviewCount.toLocaleString()} · Draft: ${draftCount.toLocaleString()}`));
+            $row.append($questCounts);
+
+            const $scheduleCell = $('<td></td>');
+            const $scheduleWrapper = $('<div class="small"></div>');
+            const $nextLine = $('<div><strong>Next:</strong> </div>');
+            if (futureCount > 0) {
+                if (line.nextRun) {
+                    const nextInfo = formatDateFromPayload(line.nextRun);
+                    const $nextSpan = $('<span></span>').text(nextInfo.text);
+                    if (nextInfo.tooltip) {
+                        $nextSpan.attr('data-bs-toggle', 'tooltip')
+                            .attr('data-bs-placement', 'bottom')
+                            .attr('data-bs-title', nextInfo.tooltip);
+                    }
+                    $nextLine.append($nextSpan);
+                } else {
+                    $nextLine.append('<span class="text-muted">Date TBD</span>');
+                }
+            } else {
+                $nextLine.append('<span class="text-muted">No quest scheduled</span>');
+            }
+            $scheduleWrapper.append($nextLine);
+
+            const $lastLine = $('<div><strong>Last:</strong> </div>');
+            if (line.lastRun) {
+                const lastInfo = formatDateFromPayload(line.lastRun);
+                const $lastSpan = $('<span></span>').text(lastInfo.text);
+                if (lastInfo.tooltip) {
+                    $lastSpan.attr('data-bs-toggle', 'tooltip')
+                        .attr('data-bs-placement', 'bottom')
+                        .attr('data-bs-title', lastInfo.tooltip);
+                }
+                $lastLine.append($lastSpan);
+            } else if (pastCount > 0) {
+                $lastLine.append('<span class="text-muted">Date TBD</span>');
+            } else {
+                $lastLine.append('<span class="text-muted">Never</span>');
+            }
+            $scheduleWrapper.append($lastLine);
+            $scheduleCell.append($scheduleWrapper);
+            $row.append($scheduleCell);
+
+            const questRating = typeof line.avgQuestRating === 'number' ? line.avgQuestRating : null;
+            const hostRating = typeof line.avgHostRating === 'number' ? line.avgHostRating : null;
+            const $ratingsCell = $('<td></td>');
+            if ((questRating && questRating > 0) || (hostRating && hostRating > 0)) {
+                const $questRatingRow = $('<div class="d-flex align-items-center"></div>');
+                $questRatingRow.append('<strong>Quest:</strong>');
+                if (questRating && questRating > 0) {
+                    $questRatingRow.append(`<span class="ms-2">${renderStarRating(questRating)}</span>`);
+                } else {
+                    $questRatingRow.append('<span class="ms-2 text-muted">—</span>');
+                }
+                const $hostRatingRow = $('<div class="d-flex align-items-center"></div>');
+                $hostRatingRow.append('<strong>Host:</strong>');
+                if (hostRating && hostRating > 0) {
+                    $hostRatingRow.append(`<span class="ms-2">${renderStarRating(hostRating)}</span>`);
+                } else {
+                    $hostRatingRow.append('<span class="ms-2 text-muted">—</span>');
+                }
+                $ratingsCell.append($questRatingRow).append($hostRatingRow);
+            } else {
+                $ratingsCell.append('<span class="text-muted">No reviews yet</span>');
+            }
+            $row.append($ratingsCell);
+
+            const participantsTotal = Number(line.participantsTotal ?? (line.metrics && line.metrics.participantsTotal));
+            const registeredTotal = Number(line.registeredTotal ?? (line.metrics && line.metrics.registeredTotal));
+            const attendanceRate = typeof line.attendanceRate === 'number' ? line.attendanceRate : null;
+            const participantsText = Number.isFinite(participantsTotal) ? participantsTotal.toLocaleString() : '—';
+            const registrationsText = Number.isFinite(registeredTotal) ? registeredTotal.toLocaleString() : '—';
+            const attendanceText = attendanceRate !== null && !Number.isNaN(attendanceRate)
+                ? `${Math.round(attendanceRate * 100)}%`
+                : '—';
+            const $engagementCell = $('<td></td>');
+            $engagementCell.append($('<div class="fw-semibold"></div>').text(participantsText));
+            $engagementCell.append($('<div class="small text-muted"></div>').text(`Registrations: ${registrationsText}`));
+            $engagementCell.append($('<div class="small text-muted"></div>').text(`Attendance: ${attendanceText}`));
+            $row.append($engagementCell);
+
+            const viewUrl = line.publicUrl || line.url || line.viewUrl || '';
+            const $actionCell = $('<td class="text-end"></td>');
+            if (isPublished && viewUrl) {
+                $actionCell.append($('<a class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener">View</a>').attr('href', viewUrl));
+            } else {
+                $actionCell.append('<button type="button" class="btn btn-sm btn-outline-secondary" disabled>View</button>');
+            }
+            $row.append($actionCell);
+
+            $tbody.append($row);
+        });
+
+        if ($alert.length) {
+            const count = Number(statusCounts.needingScheduling);
+            if (Number.isFinite(count) && count > 0) {
+                const needsVerb = count === 1 ? 'needs' : 'need';
+                const lineLabel = count === 1 ? 'quest line' : 'quest lines';
+                $alert.html(`<i class="fa-solid fa-bell me-2"></i>${count} published ${lineLabel} ${needsVerb} a scheduled follow-up. Plan the next quest to keep players engaged.`);
+                $alert.removeClass('d-none');
+            }
+        }
+
+        initializeTooltips($tbody);
+        renderSectionState('questLines', 'ready');
+    }
+
+    function renderTopSections(topData, errorMessage) {
+        const $questsWrapper = $('#topQuestsTableWrapper');
+        const $questsEmpty = $('#topQuestsEmpty');
+        const $questsBody = $('#topQuestsBody');
+        const $participantsControls = $('#topParticipantsControls');
+        const $participantsWrapper = $('#topParticipantsTableWrapper');
+        const $participantsEmpty = $('#topParticipantsEmpty');
+        const $participantsBody = $('#topParticipantsBody');
+        const $coHostsWrapper = $('#topCoHostsTableWrapper');
+        const $coHostsEmpty = $('#topCoHostsEmpty');
+        const $coHostsBody = $('#topCoHostsBody');
+
+        if ($questsBody.length) { $questsBody.empty(); }
+        if ($participantsBody.length) { $participantsBody.empty(); }
+        if ($coHostsBody.length) { $coHostsBody.empty(); }
+
+        hideElement($questsWrapper);
+        hideElement($participantsWrapper);
+        hideElement($participantsControls);
+        hideElement($coHostsWrapper);
+        hideElement($questsEmpty);
+        hideElement($participantsEmpty);
+        hideElement($coHostsEmpty);
+
+        if (errorMessage) {
+            renderSectionState('top', 'error', errorMessage);
+            return;
+        }
+
+        const renderStarRating = getStarRenderer();
+        const quests = Array.isArray(topData && topData.quests) ? topData.quests : [];
+        if (quests.length > 0 && $questsBody.length) {
+            quests.forEach((quest) => {
+                const $row = $('<tr></tr>');
+                const $questCell = $('<td></td>');
+                const $questWrap = $('<div class="d-flex align-items-center"></div>');
+                if (quest.icon) {
+                    $questWrap.append($('<img>', {
+                        src: quest.icon,
+                        class: 'rounded me-2',
+                        css: { width: '40px', height: '40px', objectFit: 'cover' },
+                        alt: quest.title || 'Quest icon'
+                    }));
+                }
+                const questTitle = quest.title || 'Quest';
+                const questUrl = resolveQuestUrl(quest);
+                $questWrap.append($('<a></a>', {
+                    href: questUrl,
+                    target: '_blank',
+                    rel: 'noopener',
+                    text: questTitle
+                }));
+                $questCell.append($questWrap);
+                $row.append($questCell);
+
+                const participants = Number(quest.participants);
+                $row.append($('<td class="align-middle"></td>').text(Number.isFinite(participants) ? participants.toLocaleString() : '—'));
+
+                const questRating = Number(quest.avgQuestRating);
+                const $questRatingCell = $('<td class="align-middle"></td>');
+                if (Number.isFinite(questRating) && questRating > 0) {
+                    $questRatingCell.html(`${renderStarRating(questRating)}<span class="ms-1">${questRating.toFixed(2)}</span>`);
+                } else {
+                    $questRatingCell.text('—');
+                }
+                $row.append($questRatingCell);
+
+                const hostRating = Number(quest.avgHostRating);
+                const $hostRatingCell = $('<td class="align-middle"></td>');
+                if (Number.isFinite(hostRating) && hostRating > 0) {
+                    $hostRatingCell.html(`${renderStarRating(hostRating)}<span class="ms-1">${hostRating.toFixed(2)}</span>`);
+                } else {
+                    $hostRatingCell.text('—');
+                }
+                $row.append($hostRatingCell);
+
+                const questId = quest.id || quest.questId || '';
+                const banner = quest.banner || quest.questBanner || '';
+                $row.append($('<td class="align-middle"></td>').append($('<button type="button" class="btn btn-sm btn-outline-primary view-reviews-btn"></button>')
+                    .attr('data-quest-id', questId)
+                    .attr('data-quest-title', questTitle)
+                    .attr('data-quest-banner', banner)
+                    .html('<i class="fa-regular fa-comments me-1"></i>Reviews')));
+
+                $row.append($('<td class="align-middle"></td>').append($('<button type="button" class="btn btn-sm btn-outline-secondary clone-quest-btn"></button>')
+                    .attr('data-quest-id', questId)
+                    .attr('data-quest-title', questTitle)
+                    .html('<i class="fa-regular fa-clone me-1"></i>Clone')));
+
+                $questsBody.append($row);
+            });
+            showElement($questsWrapper);
+        } else {
+            showElement($questsEmpty);
+        }
+
+        const participants = Array.isArray(topData && topData.participants) ? topData.participants : [];
+        if (participants.length > 0 && $participantsBody.length) {
+            participants.forEach((participant) => {
+                const loyalty = Number(participant.loyalty) || 0;
+                const reliability = Number(participant.reliability) || 0;
+                const hosted = Number(participant.questsHosted) || 0;
+                const network = Number(participant.network) || 0;
+                const $row = $('<tr></tr>')
+                    .attr('data-loyalty', loyalty)
+                    .attr('data-reliability', reliability)
+                    .attr('data-questshosted', hosted)
+                    .attr('data-network', network);
+
+                const $playerCell = $('<td></td>');
+                const $playerWrap = $('<div class="d-flex align-items-center"></div>');
+                if (participant.avatar) {
+                    $playerWrap.append($('<img>', {
+                        src: participant.avatar,
+                        class: 'rounded me-2',
+                        css: { width: '40px', height: '40px', objectFit: 'cover' },
+                        alt: participant.username || 'Participant avatar'
+                    }));
+                }
+                $playerWrap.append($('<a></a>', {
+                    href: participant.url || '#',
+                    target: '_blank',
+                    rel: 'noopener',
+                    class: 'username',
+                    text: participant.username || 'Participant'
+                }));
+                $playerCell.append($playerWrap);
+                $row.append($playerCell);
+
+                $row.append($('<td class="align-middle"></td>').text(loyalty.toLocaleString()));
+                $row.append($('<td class="align-middle"></td>').text(`${Math.round(reliability * 100)}%`));
+                $row.append($('<td class="align-middle"></td>').text(hosted.toLocaleString()));
+                $row.append($('<td class="align-middle"></td>').text(network.toLocaleString()));
+
+                const avgQuestRating = Number(participant.avgQuestRating);
+                const $avgQuestCell = $('<td class="align-middle"></td>');
+                if (Number.isFinite(avgQuestRating) && avgQuestRating > 0) {
+                    $avgQuestCell.html(`${renderStarRating(avgQuestRating)}<span class="ms-1">${avgQuestRating.toFixed(2)}</span>`);
+                } else {
+                    $avgQuestCell.text('—');
+                }
+                $row.append($avgQuestCell);
+
+                const avgHostRating = Number(participant.avgHostRating);
+                const $avgHostCell = $('<td class="align-middle"></td>');
+                if (Number.isFinite(avgHostRating) && avgHostRating > 0) {
+                    $avgHostCell.html(`${renderStarRating(avgHostRating)}<span class="ms-1">${avgHostRating.toFixed(2)}</span>`);
+                } else {
+                    $avgHostCell.text('—');
+                }
+                $row.append($avgHostCell);
+
+                $participantsBody.append($row);
+            });
+            showElement($participantsWrapper);
+            showElement($participantsControls);
+        } else {
+            showElement($participantsEmpty);
+        }
+
+        const coHosts = Array.isArray(topData && topData.coHosts) ? topData.coHosts : [];
+        if (coHosts.length > 0 && $coHostsBody.length) {
+            coHosts.forEach((host) => {
+                const $row = $('<tr></tr>');
+                const $hostCell = $('<td></td>');
+                const $hostWrap = $('<div class="d-flex align-items-center"></div>');
+                if (host.avatar) {
+                    $hostWrap.append($('<img>', {
+                        src: host.avatar,
+                        class: 'rounded me-2',
+                        css: { width: '40px', height: '40px', objectFit: 'cover' },
+                        alt: host.username || 'Co-host avatar'
+                    }));
+                }
+                $hostWrap.append($('<a></a>', {
+                    href: host.url || '#',
+                    target: '_blank',
+                    rel: 'noopener',
+                    class: 'username',
+                    text: host.username || 'Co-host'
+                }));
+                $hostCell.append($hostWrap);
+                $row.append($hostCell);
+
+                const questCount = Number(host.questCount);
+                $row.append($('<td class="align-middle"></td>').text(Number.isFinite(questCount) ? questCount.toLocaleString() : '—'));
+
+                const avgParticipants = Number(host.avgParticipants);
+                $row.append($('<td class="align-middle"></td>').text(Number.isFinite(avgParticipants) ? avgParticipants.toFixed(1) : '—'));
+
+                const uniqueParticipants = Number(host.uniqueParticipants);
+                $row.append($('<td class="align-middle"></td>').text(Number.isFinite(uniqueParticipants) ? uniqueParticipants.toLocaleString() : '—'));
+
+                const avgHostRating = Number(host.avgHostRating);
+                const $avgHostRatingCell = $('<td class="align-middle"></td>');
+                if (Number.isFinite(avgHostRating) && avgHostRating > 0) {
+                    $avgHostRatingCell.html(`${renderStarRating(avgHostRating)}<span class="ms-1">${avgHostRating.toFixed(2)}</span>`);
+                } else {
+                    $avgHostRatingCell.text('—');
+                }
+                $row.append($avgHostRatingCell);
+
+                const avgQuestRating = Number(host.avgQuestRating);
+                const $avgQuestRatingCell = $('<td class="align-middle"></td>');
+                if (Number.isFinite(avgQuestRating) && avgQuestRating > 0) {
+                    $avgQuestRatingCell.html(`${renderStarRating(avgQuestRating)}<span class="ms-1">${avgQuestRating.toFixed(2)}</span>`);
+                } else {
+                    $avgQuestRatingCell.text('—');
+                }
+                $row.append($avgQuestRatingCell);
+
+                $coHostsBody.append($row);
+            });
+            showElement($coHostsWrapper);
+        } else {
+            showElement($coHostsEmpty);
+        }
+
+        renderSectionState('top', 'ready');
+        initializeTooltips($('#topContent'));
+        document.dispatchEvent(new CustomEvent('questDashboard:participantsRendered'));
     }
 
     function initializeTooltips($container) {
@@ -598,6 +1322,9 @@
         renderUpcomingList(null, errorMessage);
         renderQuestReviewsTable(null, errorMessage);
         renderCharts(null, errorMessage);
+        renderSuggestions(null, errorMessage);
+        renderQuestLines(null, errorMessage);
+        renderTopSections(null, errorMessage);
     }
 
     function loadDashboard(sessionToken) {
@@ -605,6 +1332,10 @@
             handleError('Session expired. Please log in again.');
             return;
         }
+
+        renderSectionState('suggestions', 'loading');
+        renderSectionState('questLines', 'loading');
+        renderSectionState('top', 'loading');
 
         $.ajax({
             url: '/api/v1/quest/dashboard.php',
@@ -618,6 +1349,9 @@
                 const reviewPayload = resp.data.reviews || {};
                 renderQuestReviewsTable(reviewPayload.summaries || []);
                 renderCharts(reviewPayload.chart || {});
+                renderSuggestions(resp.data.suggestions || {});
+                renderQuestLines(resp.data.questLines || {});
+                renderTopSections(resp.data.top || {});
             } else {
                 handleError(resp && resp.message ? resp.message : null);
             }

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -312,114 +312,22 @@ function renderStarRating(float $rating): string
                 </div>
                 <div class="tab-pane fade" id="nav-suggestions" role="tabpanel" aria-labelledby="nav-suggestions-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Suggestions</div>
-                    <?php if ($recommendedQuest || $underperformingQuest || $dormantQuest || $fanFavoriteQuest || $hiddenGemQuest || !empty($coHostCandidates)) { ?>
-                        <?php if ($dormantQuest) { ?>
-                            <div class="card mb-3">
-                                <div class="card-body">
-                                    <div class="d-flex align-items-center mb-2">
-                                        <?php if (!empty($dormantQuest['icon'])) { ?>
-                                            <img src="<?= htmlspecialchars($dormantQuest['icon']); ?>" class="rounded me-3" style="width:60px;height:60px;" alt="">
-                                        <?php } ?>
-                                        <div>
-                                            <h5 class="card-title mb-1">Revive this beloved quest with a fresh twist</h5>
-                                            <?php $dormantLastRan = $dormantQuest['endDateFormatted'] ?? null; ?>
-                                            <p class="card-text mb-1"><a href="<?= htmlspecialchars(Version::formatUrl('/q/' . $dormantQuest['locator'])); ?>" target="_blank"><?= htmlspecialchars($dormantQuest['title']); ?></a> last ran <?= $dormantLastRan !== null ? htmlspecialchars($dormantLastRan) : 'date TBD'; ?></p>
-                        <p class="card-text mb-0">
-                                                Quest Rating: <?= renderStarRating($dormantQuest['avgQuestRating']); ?><span class="ms-1"><?= number_format($dormantQuest['avgQuestRating'], 1); ?></span>
-                                                &middot; Host Rating: <?= renderStarRating($dormantQuest['avgHostRating']); ?><span class="ms-1"><?= number_format($dormantQuest['avgHostRating'], 1); ?></span>
-                                            </p>
-                                        </div>
-                                    </div>
-                                    <p class="card-text mb-2"><?= QuestDashboardService::generateBringBackSuggestion($dormantQuest); ?></p>
-                                    <div class="mt-2 d-flex flex-wrap gap-2">
-                                        <button class="btn btn-sm btn-outline-primary view-reviews-btn" data-quest-id="<?= $dormantQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($dormantQuest['title']); ?>" data-quest-banner="<?= htmlspecialchars($dormantQuest['banner']); ?>"><i class="fa-regular fa-comments me-1"></i>Reviews</button>
-                                        <button class="btn btn-sm btn-outline-secondary clone-quest-btn" data-quest-id="<?= $dormantQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($dormantQuest['title']); ?>"><i class="fa-regular fa-clone me-1"></i>Clone Quest</button>
-                                    </div>
-                                </div>
+                    <div id="suggestionsSection">
+                        <div id="suggestionsSpinner" class="section-spinner text-center py-3">
+                            <div class="spinner-border text-secondary" role="status">
+                                <span class="visually-hidden">Loading...</span>
                             </div>
-                        <?php } ?>
-                        <?php if ($fanFavoriteQuest) { ?>
-                            <div class="card mb-3">
-                                <div class="card-body">
-                                    <div class="d-flex align-items-center mb-2">
-                                        <?php if (!empty($fanFavoriteQuest['icon'])) { ?>
-                                            <img src="<?= htmlspecialchars($fanFavoriteQuest['icon']); ?>" class="rounded me-3" style="width:60px;height:60px;" alt="">
-                                        <?php } ?>
-                                        <div>
-                                            <h5 class="card-title mb-1">Reward loyal players with a long-awaited sequel</h5>
-                                            <?php $fanFavoriteLastRan = $fanFavoriteQuest['endDateFormatted'] ?? null; ?>
-                                            <p class="card-text mb-1"><a href="<?= htmlspecialchars(Version::formatUrl('/q/' . $fanFavoriteQuest['locator'])); ?>" target="_blank"><?= htmlspecialchars($fanFavoriteQuest['title']); ?></a> last ran <?= $fanFavoriteLastRan !== null ? htmlspecialchars($fanFavoriteLastRan) : 'date TBD'; ?></p>
-                                            <p class="card-text mb-0">
-                                                Quest Rating: <?= renderStarRating($fanFavoriteQuest['avgQuestRating']); ?><span class="ms-1"><?= number_format($fanFavoriteQuest['avgQuestRating'], 1); ?></span>
-                                                &middot; Host Rating: <?= renderStarRating($fanFavoriteQuest['avgHostRating']); ?><span class="ms-1"><?= number_format($fanFavoriteQuest['avgHostRating'], 1); ?></span>
-                                            </p>
-                                        </div>
-                                    </div>
-                                    <p class="card-text mb-2"><?= QuestDashboardService::generateSequelSuggestion($fanFavoriteQuest); ?></p>
-                                    <div class="mt-2 d-flex flex-wrap gap-2">
-                                        <button class="btn btn-sm btn-outline-primary view-reviews-btn" data-quest-id="<?= $fanFavoriteQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($fanFavoriteQuest['title']); ?>" data-quest-banner="<?= htmlspecialchars($fanFavoriteQuest['banner']); ?>"><i class="fa-regular fa-comments me-1"></i>Reviews</button>
-                                        <button class="btn btn-sm btn-outline-secondary clone-quest-btn" data-quest-id="<?= $fanFavoriteQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($fanFavoriteQuest['title']); ?>"><i class="fa-regular fa-clone me-1"></i>Clone Quest</button>
-                                    </div>
-                                </div>
-                            </div>
-                        <?php } ?>
-                        <?php if ($recommendedQuest) { ?>
-                            <div class="card mb-3">
-                                <div class="card-body">
-                                    <div class="d-flex align-items-center mb-2">
-                                        <?php if (!empty($recommendedQuest['icon'])) { ?>
-                                            <img src="<?= htmlspecialchars($recommendedQuest['icon']); ?>" class="rounded me-3" style="width:60px;height:60px;" alt="">
-                                        <?php } ?>
-                                        <div>
-                                            <h5 class="card-title mb-1">Launch a new quest inspired by your top performer</h5>
-                                            <?php $recommendedLastRan = $recommendedQuest['endDateFormatted'] ?? null; ?>
-                                            <p class="card-text mb-1"><a href="<?= htmlspecialchars(Version::formatUrl('/q/' . $recommendedQuest['locator'])); ?>" target="_blank"><?= htmlspecialchars($recommendedQuest['title']); ?></a> last ran <?= $recommendedLastRan !== null ? htmlspecialchars($recommendedLastRan) : 'date TBD'; ?></p>
-                                            <p class="card-text mb-0">
-                                                Quest Rating: <?= renderStarRating($recommendedQuest['avgQuestRating']); ?><span class="ms-1"><?= number_format($recommendedQuest['avgQuestRating'], 1); ?></span>
-                                                &middot; Host Rating: <?= renderStarRating($recommendedQuest['avgHostRating']); ?><span class="ms-1"><?= number_format($recommendedQuest['avgHostRating'], 1); ?></span>
-                                            </p>
-                                        </div>
-                                    </div>
-                                    <p class="card-text mb-2"><?= QuestDashboardService::generateSimilarQuestSuggestion($recommendedQuest); ?></p>
-                                    <div class="mt-2 d-flex flex-wrap gap-2">
-                                        <button class="btn btn-sm btn-outline-primary view-reviews-btn" data-quest-id="<?= $recommendedQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($recommendedQuest['title']); ?>" data-quest-banner="<?= htmlspecialchars($recommendedQuest['banner']); ?>"><i class="fa-regular fa-comments me-1"></i>Reviews</button>
-                                        <button class="btn btn-sm btn-outline-secondary clone-quest-btn" data-quest-id="<?= $recommendedQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($recommendedQuest['title']); ?>"><i class="fa-regular fa-clone me-1"></i>Clone Quest</button>
-                                    </div>
-                                </div>
-                            </div>
-                        <?php } ?>
-                        <?php if ($hiddenGemQuest) { ?>
-                            <div class="card mb-3">
-                                <div class="card-body">
-                                    <div class="d-flex align-items-center mb-2">
-                                        <?php if (!empty($hiddenGemQuest['icon'])) { ?>
-                                            <img src="<?= htmlspecialchars($hiddenGemQuest['icon']); ?>" class="rounded me-3" style="width:60px;height:60px;" alt="">
-                                        <?php } ?>
-                                        <div>
-                                            <h5 class="card-title mb-1">Relaunch this highly rated quest with stronger promotion</h5>
-                                            <?php $hiddenGemLastRan = $hiddenGemQuest['endDateFormatted'] ?? null; ?>
-                                            <p class="card-text mb-1"><a href="<?= htmlspecialchars(Version::formatUrl('/q/' . $hiddenGemQuest['locator'])); ?>" target="_blank"><?= htmlspecialchars($hiddenGemQuest['title']); ?></a> last ran <?= $hiddenGemLastRan !== null ? htmlspecialchars($hiddenGemLastRan) : 'date TBD'; ?></p>
-                                            <p class="card-text mb-0">
-                                                Quest Rating: <?= renderStarRating($hiddenGemQuest['avgQuestRating']); ?><span class="ms-1"><?= number_format($hiddenGemQuest['avgQuestRating'], 1); ?></span>
-                                                &middot; Host Rating: <?= renderStarRating($hiddenGemQuest['avgHostRating']); ?><span class="ms-1"><?= number_format($hiddenGemQuest['avgHostRating'], 1); ?></span>
-                                            </p>
-                                        </div>
-                                    </div>
-                                    <p class="card-text mb-2"><?= QuestDashboardService::generatePromoteQuestSuggestion($hiddenGemQuest); ?></p>
-                                    <div class="mt-2 d-flex flex-wrap gap-2">
-                                        <button class="btn btn-sm btn-outline-primary view-reviews-btn" data-quest-id="<?= $hiddenGemQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($hiddenGemQuest['title']); ?>" data-quest-banner="<?= htmlspecialchars($hiddenGemQuest['banner']); ?>"><i class="fa-regular fa-comments me-1"></i>Reviews</button>
-                                        <button class="btn btn-sm btn-outline-secondary clone-quest-btn" data-quest-id="<?= $hiddenGemQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($hiddenGemQuest['title']); ?>"><i class="fa-regular fa-clone me-1"></i>Clone Quest</button>
-                                    </div>
-                                </div>
-                            </div>
-                        <?php } ?>
-                        <?php if (!empty($coHostCandidates)) { ?>
-                            <div class="card mb-3">
+                        </div>
+                        <div id="suggestionsError" class="alert alert-danger d-none" role="alert"></div>
+                        <p id="suggestionsEmpty" class="text-muted d-none">No suggestions found. Keep hosting adventures!</p>
+                        <div id="suggestionsContent" class="d-none">
+                            <div id="suggestionCards" class="mb-3"></div>
+                            <div id="coHostSuggestionCard" class="card d-none">
                                 <div class="card-body">
                                     <h5 class="card-title mb-3">Partner with a co-host to expand your reach</h5>
                                     <p class="card-text mb-3">Partner with reliable players to manage larger quests and reach new audiences.</p>
                                     <div class="table-responsive">
-                                        <table class="table table-striped mb-0">
+                                        <table class="table table-striped mb-0" id="coHostSuggestionTable">
                                             <thead>
                                                 <tr>
                                                     <th>Player</th>
@@ -430,250 +338,96 @@ function renderStarRating(float $rating): string
                                                     <th>Last Quest</th>
                                                 </tr>
                                             </thead>
-                                            <tbody>
-                                                <?php foreach ($coHostCandidates as $coHostCandidate) { ?>
-                                                    <tr>
-                                                        <td>
-                                                            <div class="d-flex align-items-center">
-                                                                <?php if (!empty($coHostCandidate['avatar'])) { ?>
-                                                                    <img src="<?= htmlspecialchars($coHostCandidate['avatar']); ?>" class="rounded me-2" style="width:40px;height:40px;" alt="">
-                                                                <?php } ?>
-                                                                <a href="<?= htmlspecialchars($coHostCandidate['url']); ?>" target="_blank" class="username"><?= htmlspecialchars($coHostCandidate['username']); ?></a>
-                                                            </div>
-                                                        </td>
-                                                        <td class="align-middle"><?= $coHostCandidate['loyalty']; ?></td>
-                                                        <td class="align-middle"><?= number_format($coHostCandidate['reliability'] * 100, 0); ?>%</td>
-                                                        <td class="align-middle"><?= $coHostCandidate['questsHosted']; ?></td>
-                                                        <td class="align-middle"><?= $coHostCandidate['network']; ?></td>
-                                                        <td class="align-middle">
-                                                            <?php if (isset($coHostCandidate['daysSinceLastQuest'])) { ?>
-                                                                <?= $coHostCandidate['daysSinceLastQuest']; ?> day<?= $coHostCandidate['daysSinceLastQuest'] === 1 ? '' : 's'; ?> ago
-                                                            <?php } else { ?>
-                                                                &ndash;
-                                                            <?php } ?>
-                                                        </td>
-                                                    </tr>
-                                                <?php } ?>
-                                            </tbody>
+                                            <tbody></tbody>
                                         </table>
                                     </div>
                                 </div>
                             </div>
-                        <?php } ?>
-                        <?php if ($underperformingQuest) { ?>
-                            <div class="card mb-3">
-                                <div class="card-body">
-                                    <div class="d-flex align-items-center mb-2">
-                                        <?php if (!empty($underperformingQuest['icon'])) { ?>
-                                            <img src="<?= htmlspecialchars($underperformingQuest['icon']); ?>" class="rounded me-3" style="width:60px;height:60px;" alt="">
-                                        <?php } ?>
-                                        <div>
-                                            <h5 class="card-title mb-1">Refine this quest to improve its performance</h5>
-                                            <?php $underperformingLastRan = $underperformingQuest['endDateFormatted'] ?? null; ?>
-                                            <p class="card-text mb-1"><a href="<?= htmlspecialchars(Version::formatUrl('/q/' . $underperformingQuest['locator'])); ?>" target="_blank"><?= htmlspecialchars($underperformingQuest['title']); ?></a> last ran <?= $underperformingLastRan !== null ? htmlspecialchars($underperformingLastRan) : 'date TBD'; ?></p>
-                                            <p class="card-text mb-0">
-                                                Quest Rating: <?= renderStarRating($underperformingQuest['avgQuestRating']); ?><span class="ms-1"><?= number_format($underperformingQuest['avgQuestRating'], 1); ?></span>
-                                                &middot; Host Rating: <?= renderStarRating($underperformingQuest['avgHostRating']); ?><span class="ms-1"><?= number_format($underperformingQuest['avgHostRating'], 1); ?></span>
-                                            </p>
-                                        </div>
-                                    </div>
-                                    <p class="card-text mb-2"><?= QuestDashboardService::generateImproveQuestSuggestion($underperformingQuest); ?></p>
-                                    <div class="mt-2 d-flex flex-wrap gap-2">
-                                        <button class="btn btn-sm btn-outline-primary view-reviews-btn" data-quest-id="<?= $underperformingQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($underperformingQuest['title']); ?>" data-quest-banner="<?= htmlspecialchars($underperformingQuest['banner']); ?>"><i class="fa-regular fa-comments me-1"></i>Reviews</button>
-                                        <button class="btn btn-sm btn-outline-secondary clone-quest-btn" data-quest-id="<?= $underperformingQuest['id']; ?>" data-quest-title="<?= htmlspecialchars($underperformingQuest['title']); ?>"><i class="fa-regular fa-clone me-1"></i>Clone Quest</button>
-                                    </div>
-                                </div>
-                            </div>
-                        <?php } ?>
-                    <?php } else { ?>
-                        <p>No suggestions found. Keep hosting adventures!</p>
-                    <?php } ?>
+                        </div>
+                    </div>
                 </div>
                 <div class="tab-pane fade" id="nav-quest-lines" role="tabpanel" aria-labelledby="nav-quest-lines-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Quest Lines</div>
                     <p class="text-muted">Monitor your quest lines and spot where to plan the next adventure.</p>
-                    <?php if ($questLinesError) { ?>
-                        <div class="alert alert-danger" role="alert">
-                            <i class="fa-solid fa-circle-exclamation me-2"></i><?= htmlspecialchars($questLinesError); ?>
+                    <div id="questLinesSection">
+                        <div id="questLinesSpinner" class="section-spinner text-center py-3">
+                            <div class="spinner-border text-secondary" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                            </div>
                         </div>
-                    <?php } elseif (empty($questLines)) { ?>
-                        <div class="card border-0 shadow-sm">
+                        <div id="questLinesError" class="alert alert-danger d-none" role="alert"></div>
+                        <div id="questLinesEmpty" class="card border-0 shadow-sm d-none">
                             <div class="card-body text-center">
                                 <p class="mb-2">You haven't created any quest lines yet.</p>
                                 <a class="btn btn-primary" href="<?= Version::urlBetaPrefix(); ?>/quest-line.php?new"><i class="fa-solid fa-plus me-1"></i>Create your first quest line</a>
                             </div>
                         </div>
-                    <?php } else { ?>
-                        <div class="row g-3 mb-3">
-                            <div class="col-12 col-md-3">
-                                <div class="card h-100">
-                                    <div class="card-body">
-                                        <small>Total Quest Lines</small>
-                                        <h3 class="mb-0"><?= $questLineStatusCounts['total']; ?></h3>
-                                        <div class="text-muted small">With upcoming quests: <?= $questLineStatusCounts['withUpcoming']; ?></div>
-                                        <div class="text-muted small">No quests yet: <?= $questLineStatusCounts['withoutQuests']; ?></div>
+                        <div id="questLinesContent" class="d-none">
+                            <div class="row g-3 mb-3">
+                                <div class="col-12 col-md-3">
+                                    <div class="card h-100">
+                                        <div class="card-body">
+                                            <small>Total Quest Lines</small>
+                                            <h3 class="mb-0" data-quest-line-count="total">—</h3>
+                                            <div class="text-muted small">With upcoming quests: <span data-quest-line-count="withUpcoming">—</span></div>
+                                            <div class="text-muted small">No quests yet: <span data-quest-line-count="withoutQuests">—</span></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-3">
+                                    <div class="card h-100">
+                                        <div class="card-body">
+                                            <small>Published</small>
+                                            <h3 class="mb-0" data-quest-line-count="published">—</h3>
+                                            <div class="text-muted small">Need scheduling: <span data-quest-line-count="needingScheduling">—</span></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-3">
+                                    <div class="card h-100">
+                                        <div class="card-body">
+                                            <small>In Review</small>
+                                            <h3 class="mb-0" data-quest-line-count="inReview">—</h3>
+                                            <div class="text-muted small">Pending approval</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-3">
+                                    <div class="card h-100">
+                                        <div class="card-body">
+                                            <small>Drafts</small>
+                                            <h3 class="mb-0" data-quest-line-count="draft">—</h3>
+                                            <div class="text-muted small">Finish setup to publish</div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-12 col-md-3">
-                                <div class="card h-100">
-                                    <div class="card-body">
-                                        <small>Published</small>
-                                        <h3 class="mb-0"><?= $questLineStatusCounts['published']; ?></h3>
-                                        <div class="text-muted small">Need scheduling: <?= $questLineStatusCounts['needingScheduling']; ?></div>
-                                    </div>
+                            <div class="card mb-3">
+                                <div class="card-header d-flex align-items-center">
+                                    <span class="fw-semibold">Quest Line Overview</span>
+                                    <a class="btn btn-sm btn-outline-primary ms-auto" href="<?= Version::urlBetaPrefix(); ?>/quest-line.php?new"><i class="fa-solid fa-plus me-1"></i>Create Quest Line</a>
                                 </div>
-                            </div>
-                            <div class="col-12 col-md-3">
-                                <div class="card h-100">
-                                    <div class="card-body">
-                                        <small>In Review</small>
-                                        <h3 class="mb-0"><?= $questLineStatusCounts['inReview']; ?></h3>
-                                        <div class="text-muted small">Pending approval</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-md-3">
-                                <div class="card h-100">
-                                    <div class="card-body">
-                                        <small>Drafts</small>
-                                        <h3 class="mb-0"><?= $questLineStatusCounts['draft']; ?></h3>
-                                        <div class="text-muted small">Finish setup to publish</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="card mb-3">
-                            <div class="card-header d-flex align-items-center">
-                                <span class="fw-semibold">Quest Line Overview</span>
-                                <a class="btn btn-sm btn-outline-primary ms-auto" href="<?= Version::urlBetaPrefix(); ?>/quest-line.php?new"><i class="fa-solid fa-plus me-1"></i>Create Quest Line</a>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-hover mb-0 align-middle">
-                                        <thead>
-                                            <tr>
-                                                <th>Quest Line</th>
-                                                <th>Quests</th>
-                                                <th>Schedule</th>
-                                                <th>Ratings</th>
-                                                <th>Engagement</th>
-                                                <th class="text-end">Actions</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <?php foreach ($questLineStatsList as $lineStats) {
-                                                $questLine = $lineStats['questLine'];
-                                                $publicUrl = $questLine->url();
-                                                $statusLabel = $questLine->reviewStatus->published ? 'Published' : ($questLine->reviewStatus->beingReviewed ? 'In Review' : 'Draft');
-                                                $statusBadgeClass = $questLine->reviewStatus->published ? 'bg-success' : ($questLine->reviewStatus->beingReviewed ? 'bg-warning text-dark' : 'bg-secondary');
-                                                $hasUpcoming = $lineStats['futureCount'] > 0;
-                                                $needsScheduling = $questLine->reviewStatus->published && $lineStats['futureCount'] === 0 && $lineStats['questCount'] > 0;
-                                                $noQuestsYet = $lineStats['questCount'] === 0;
-                                            ?>
+                                <div class="card-body p-0">
+                                    <div class="table-responsive">
+                                        <table class="table table-striped table-hover mb-0 align-middle" id="questLinesTable">
+                                            <thead>
                                                 <tr>
-                                                    <td>
-                                                        <div class="d-flex align-items-center">
-                                                            <?php if ($questLine->icon) { ?>
-                                                                <img src="<?= htmlspecialchars($questLine->icon->getFullPath()); ?>" class="rounded me-2" style="width:48px;height:48px;object-fit:cover;" alt="">
-                                                            <?php } ?>
-                                                            <div>
-                                                                <div class="fw-semibold"><?= htmlspecialchars($questLine->title); ?></div>
-                                                                <div class="small">
-                                                                    <span class="badge <?= $statusBadgeClass; ?> me-1"><?= $statusLabel; ?></span>
-                                                                    <?php if ($hasUpcoming) { ?><span class="badge bg-info text-dark me-1">Upcoming quests</span><?php } ?>
-                                                                    <?php if ($needsScheduling) { ?><span class="badge bg-warning text-dark me-1">Needs scheduling</span><?php } ?>
-                                                                    <?php if ($noQuestsYet) { ?><span class="badge bg-secondary me-1">No quests yet</span><?php } ?>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </td>
-                                                    <td>
-                                                        <div class="fw-semibold"><?= $lineStats['questCount']; ?></div>
-                                                        <div class="small text-muted"><?= $lineStats['futureCount']; ?> upcoming &middot; <?= $lineStats['pastCount']; ?> past</div>
-                                                        <div class="small text-muted">Published: <?= $lineStats['publishedQuests']; ?> &middot; Review: <?= $lineStats['inReviewQuests']; ?> &middot; Draft: <?= $lineStats['draftQuests']; ?></div>
-                                                    </td>
-                                                    <td>
-                                                        <div class="small">
-                                                            <div><strong>Next:</strong>
-                                                                <?php if ($lineStats['futureCount'] > 0) { ?>
-                                                                    <?php if ($lineStats['nextRun'] instanceof vDateTime) { ?>
-                                                                        <?= $lineStats['nextRun']->getDateTimeElement(); ?>
-                                                                    <?php } else { ?>
-                                                                        <span class="text-muted">Date TBD</span>
-                                                                    <?php } ?>
-                                                                <?php } else { ?>
-                                                                    <span class="text-muted">No quest scheduled</span>
-                                                                <?php } ?>
-                                                            </div>
-                                                            <div><strong>Last:</strong>
-                                                                <?php if ($lineStats['lastRun'] instanceof vDateTime) { ?>
-                                                                    <?= $lineStats['lastRun']->getDateTimeElement(); ?>
-                                                                <?php } elseif ($lineStats['pastCount'] > 0) { ?>
-                                                                    <span class="text-muted">Date TBD</span>
-                                                                <?php } else { ?>
-                                                                    <span class="text-muted">Never</span>
-                                                                <?php } ?>
-                                                            </div>
-                                                        </div>
-                                                    </td>
-                                                    <td>
-                                                        <?php if ($lineStats['avgQuestRating'] !== null || $lineStats['avgHostRating'] !== null) { ?>
-                                                            <div class="d-flex align-items-center">
-                                                                <strong>Quest:</strong>
-                                                                <?php if ($lineStats['avgQuestRating'] !== null) { ?>
-                                                                    <span class="ms-2"><?= renderStarRating($lineStats['avgQuestRating']); ?></span>
-                                                                <?php } else { ?>
-                                                                    <span class="ms-2 text-muted">&ndash;</span>
-                                                                <?php } ?>
-                                                            </div>
-                                                            <div class="d-flex align-items-center">
-                                                                <strong>Host:</strong>
-                                                                <?php if ($lineStats['avgHostRating'] !== null) { ?>
-                                                                    <span class="ms-2"><?= renderStarRating($lineStats['avgHostRating']); ?></span>
-                                                                <?php } else { ?>
-                                                                    <span class="ms-2 text-muted">&ndash;</span>
-                                                                <?php } ?>
-                                                            </div>
-                                                        <?php } else { ?>
-                                                            <span class="text-muted">No reviews yet</span>
-                                                        <?php } ?>
-                                                    </td>
-                                                    <td>
-                                                        <div class="fw-semibold"><?= $lineStats['participantsTotal']; ?></div>
-                                                        <div class="small text-muted">Registrations: <?= $lineStats['registeredTotal']; ?></div>
-                                                        <div class="small text-muted">Attendance:
-                                                            <?php if ($lineStats['attendanceRate'] !== null) { ?>
-                                                                <?= number_format($lineStats['attendanceRate'] * 100, 0); ?>%
-                                                            <?php } else { ?>
-                                                                &ndash;
-                                                            <?php } ?>
-                                                        </div>
-                                                    </td>
-                                                    <td class="text-end">
-                                                        <?php if ($questLine->reviewStatus->published) { ?>
-                                                            <a href="<?= htmlspecialchars($publicUrl); ?>" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary">View</a>
-                                                        <?php } else { ?>
-                                                            <button type="button" class="btn btn-sm btn-outline-secondary" disabled>View</button>
-                                                        <?php } ?>
-                                                    </td>
+                                                    <th>Quest Line</th>
+                                                    <th>Quests</th>
+                                                    <th>Schedule</th>
+                                                    <th>Ratings</th>
+                                                    <th>Engagement</th>
+                                                    <th class="text-end">Actions</th>
                                                 </tr>
-                                            <?php } ?>
-                                        </tbody>
-                                    </table>
+                                            </thead>
+                                            <tbody id="questLinesTableBody"></tbody>
+                                        </table>
+                                    </div>
                                 </div>
                             </div>
+                            <div id="questLinesSchedulingAlert" class="alert alert-warning d-none" role="alert"></div>
                         </div>
-                        <?php if ($questLineStatusCounts['needingScheduling'] > 0) {
-                            $count = $questLineStatusCounts['needingScheduling'];
-                            $needsVerb = $count === 1 ? 'needs' : 'need';
-                            $lineLabel = $count === 1 ? 'quest line' : 'quest lines';
-                        ?>
-                            <div class="alert alert-warning" role="alert">
-                                <i class="fa-solid fa-bell me-2"></i><?= $count; ?> published <?= $lineLabel; ?> <?= $needsVerb; ?> a scheduled follow-up. Plan the next quest to keep players engaged.
-                            </div>
-                        <?php } ?>
-                    <?php } ?>
+                    </div>
                 </div>
                 <div class="tab-pane fade" id="nav-schedule" role="tabpanel" aria-labelledby="nav-schedule-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Schedule Planning</div>
@@ -718,188 +472,118 @@ function renderStarRating(float $rating): string
                 </div>
                 <div class="tab-pane fade" id="nav-top" role="tabpanel" aria-labelledby="nav-top-tab" tabindex="0">
                     <div class="display-6 tab-pane-title">Top Quests & Participants</div>
-                    <div class="accordion" id="topAccordion">
-                        <div class="accordion-item">
-                            <h2 class="accordion-header" id="headingTopQuests">
-                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTopQuests" aria-expanded="true" aria-controls="collapseTopQuests">
-                                    Top 10 Quests
-                                </button>
-                            </h2>
-                            <div id="collapseTopQuests" class="accordion-collapse collapse show" aria-labelledby="headingTopQuests">
-                                <div class="accordion-body">
-                                    <?php if (count($topBestQuests) === 0) { ?>
-                                        <p>No completed quests.</p>
-                                    <?php } else { ?>
-                                        <div class="table-responsive">
-                                            <table class="table table-striped">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Quest</th>
-                                                        <th>Participants</th>
-                                                        <th>Avg Quest Rating</th>
-                                                        <th>Avg Host Rating</th>
-                                                        <th>Reviews</th>
-                                                        <th>Clone</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <?php foreach ($topBestQuests as $q) { ?>
-                                                        <tr>
-                                                            <td>
-                                                                <div class="d-flex align-items-center">
-                                                                    <?php if (!empty($q['icon'])) { ?>
-                                                                        <img src="<?= htmlspecialchars($q['icon']); ?>" class="rounded me-2" style="width:40px;height:40px;" alt="">
-                                                                    <?php } ?>
-                                                                    <a href="<?= htmlspecialchars(Version::formatUrl('/q/' . $q['locator'])); ?>" target="_blank"><?= htmlspecialchars($q['title']); ?></a>
-                                                                </div>
-                                                            </td>
-                                                            <td class="align-middle"><?= $q['participants']; ?></td>
-                                                            <td class="align-middle">
-                                                                <?= renderStarRating($q['avgQuestRating']); ?><span class="ms-1"><?= number_format($q['avgQuestRating'], 2); ?></span>
-                                                            </td>
-                                                            <td class="align-middle">
-                                                                <?= renderStarRating($q['avgHostRating']); ?><span class="ms-1"><?= number_format($q['avgHostRating'], 2); ?></span>
-                                                            </td>
-                                                            <td class="align-middle">
-                                                                <button class="btn btn-sm btn-outline-primary view-reviews-btn" data-quest-id="<?= $q['id']; ?>" data-quest-title="<?= htmlspecialchars($q['title']); ?>" data-quest-banner="<?= htmlspecialchars($q['banner']); ?>"><i class="fa-regular fa-comments me-1"></i>Reviews</button>
-                                                            </td>
-                                                            <td class="align-middle">
-                                                                <button class="btn btn-sm btn-outline-secondary clone-quest-btn" data-quest-id="<?= $q['id']; ?>" data-quest-title="<?= htmlspecialchars($q['title']); ?>"><i class="fa-regular fa-clone me-1"></i>Clone</button>
-                                                            </td>
-                                                        </tr>
-                                                    <?php } ?>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    <?php } ?>
-                                </div>
+                    <div id="topSection">
+                        <div id="topSpinner" class="section-spinner text-center py-3">
+                            <div class="spinner-border text-secondary" role="status">
+                                <span class="visually-hidden">Loading...</span>
                             </div>
                         </div>
-                        <div class="accordion-item">
-                            <h2 class="accordion-header" id="headingTopParticipants">
-                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTopParticipants" aria-expanded="false" aria-controls="collapseTopParticipants">
-                                    Top 10 Loyal Participants
-                                </button>
-                            </h2>
-                            <div id="collapseTopParticipants" class="accordion-collapse collapse" aria-labelledby="headingTopParticipants">
-                                <div class="accordion-body">
-                                    <?php if (count($topParticipants) === 0) { ?>
-                                        <p>No participants yet.</p>
-                                    <?php } else { ?>
-                                        <div class="mb-3">
-                                            <label for="participantSort" class="form-label">Sort by:</label>
-                                            <select id="participantSort" class="form-select form-select-sm" style="max-width:200px;">
-                                                <option value="loyalty">Quests Joined</option>
-                                                <option value="reliability">Reliability</option>
-                                                <option value="questshosted">Hosted Quests</option>
-                                                <option value="network">Network Reach</option>
-                                            </select>
-                                        </div>
-                                        <div class="row mb-3 g-2">
-                                            <div class="col">
-                                                <input type="number" id="reliabilityFilter" class="form-control form-control-sm" placeholder="Min reliability %">
-                                            </div>
-                                            <div class="col">
-                                                <input type="number" id="hostedFilter" class="form-control form-control-sm" placeholder="Min hosted quests">
-                                            </div>
-                                            <div class="col">
-                                                <input type="number" id="networkFilter" class="form-control form-control-sm" placeholder="Min network reach">
-                                            </div>
-                                        </div>
-                                        <div class="table-responsive">
-                                            <table class="table table-striped" id="topParticipantsTable">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Participant</th>
-                                                        <th>Quests Joined</th>
-                                                        <th>Reliability</th>
-                                                        <th>Hosted Quests</th>
-                                                        <th>Network</th>
-                                                        <th>Avg Quest Rating</th>
-                                                        <th>Avg Host Rating</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <?php foreach ($topParticipants as $p) { ?>
-                                                        <tr data-loyalty="<?= $p['loyalty']; ?>" data-reliability="<?= $p['reliability']; ?>" data-questshosted="<?= $p['questsHosted']; ?>" data-network="<?= $p['network']; ?>">
-                                                            <td>
-                                                                <div class="d-flex align-items-center">
-                                                                    <img src="<?= htmlspecialchars($p['avatar']); ?>" class="rounded me-2" style="width:40px;height:40px;" alt="">
-                                                                    <div><a href="<?= htmlspecialchars($p['url']); ?>" target="_blank" class="username"><?= htmlspecialchars($p['username']); ?></a></div>
-                                                                </div>
-                                                            </td>
-                                                            <td class="align-middle"><?= $p['loyalty']; ?></td>
-                                                            <td class="align-middle"><?= number_format($p['reliability'] * 100, 0); ?>%</td>
-                                                            <td class="align-middle"><?= $p['questsHosted']; ?></td>
-                                                            <td class="align-middle"><?= $p['network']; ?></td>
-                                                            <td class="align-middle">
-                                                                <?= renderStarRating($p['avgQuestRating']); ?>
-                                                                <span class="ms-1"><?= number_format($p['avgQuestRating'], 2); ?></span>
-                                                            </td>
-                                                            <td class="align-middle">
-                                                                <?= renderStarRating($p['avgHostRating']); ?>
-                                                                <span class="ms-1"><?= number_format($p['avgHostRating'], 2); ?></span>
-                                                            </td>
-                                                        </tr>
-                                                    <?php } ?>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    <?php } ?>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="accordion-item">
-                            <h2 class="accordion-header" id="headingTopCoHosts">
-                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTopCoHosts" aria-expanded="false" aria-controls="collapseTopCoHosts">
-                                    Top 10 Co-Hosts
-                                </button>
-                            </h2>
-                            <div id="collapseTopCoHosts" class="accordion-collapse collapse" aria-labelledby="headingTopCoHosts">
-                                <div class="accordion-body">
-                                    <?php if (count($topCoHosts) === 0) { ?>
-                                        <p>No co-hosts yet.</p>
-                                    <?php } else { ?>
-                                        <div class="table-responsive">
-                                            <table class="table table-striped">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Co-Host</th>
-                                                        <th>Quests Co-Hosted</th>
-                                                        <th>Avg Participants</th>
-                                                        <th>Unique Participants</th>
-                                                        <th>Avg Host Rating</th>
-                                                        <th>Avg Quest Rating</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <?php foreach ($topCoHosts as $h) { ?>
+                        <div id="topError" class="alert alert-danger d-none" role="alert"></div>
+                        <div id="topContent" class="d-none">
+                            <div class="accordion" id="topAccordion">
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="headingTopQuests">
+                                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTopQuests" aria-expanded="true" aria-controls="collapseTopQuests">
+                                            Top 10 Quests
+                                        </button>
+                                    </h2>
+                                    <div id="collapseTopQuests" class="accordion-collapse collapse show" aria-labelledby="headingTopQuests">
+                                        <div class="accordion-body">
+                                            <p id="topQuestsEmpty" class="text-muted d-none mb-0">No completed quests.</p>
+                                            <div class="table-responsive d-none" id="topQuestsTableWrapper">
+                                                <table class="table table-striped" id="topQuestsTable">
+                                                    <thead>
                                                         <tr>
-                                                            <td>
-                                                                <div class="d-flex align-items-center">
-                                                                    <?php if (!empty($h['avatar'])) { ?>
-                                                                        <img src="<?= htmlspecialchars($h['avatar']); ?>" class="rounded me-2" style="width:40px;height:40px;" alt="">
-                                                                    <?php } ?>
-                                                                    <div><a href="<?= htmlspecialchars($h['url']); ?>" target="_blank" class="username"><?= htmlspecialchars($h['username']); ?></a></div>
-                                                                </div>
-                                                            </td>
-                                                            <td class="align-middle"><?= $h['questCount']; ?></td>
-                                                            <td class="align-middle"><?= number_format($h['avgParticipants'], 1); ?></td>
-                                                            <td class="align-middle"><?= $h['uniqueParticipants']; ?></td>
-                                                            <td class="align-middle">
-                                                                <?= renderStarRating($h['avgHostRating']); ?>
-                                                                <span class="ms-1"><?= number_format($h['avgHostRating'], 2); ?></span>
-                                                            </td>
-                                                            <td class="align-middle">
-                                                                <?= renderStarRating($h['avgQuestRating']); ?>
-                                                                <span class="ms-1"><?= number_format($h['avgQuestRating'], 2); ?></span>
-                                                            </td>
+                                                            <th>Quest</th>
+                                                            <th>Participants</th>
+                                                            <th>Avg Quest Rating</th>
+                                                            <th>Avg Host Rating</th>
+                                                            <th>Reviews</th>
+                                                            <th>Clone</th>
                                                         </tr>
-                                                   <?php } ?>
-                                                </tbody>
-                                            </table>
+                                                    </thead>
+                                                    <tbody id="topQuestsBody"></tbody>
+                                                </table>
+                                            </div>
                                         </div>
-                                    <?php } ?>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="headingTopParticipants">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTopParticipants" aria-expanded="false" aria-controls="collapseTopParticipants">
+                                            Top 10 Loyal Participants
+                                        </button>
+                                    </h2>
+                                    <div id="collapseTopParticipants" class="accordion-collapse collapse" aria-labelledby="headingTopParticipants">
+                                        <div class="accordion-body">
+                                            <p id="topParticipantsEmpty" class="text-muted d-none mb-0">No participants yet.</p>
+                                            <div id="topParticipantsControls" class="d-none">
+                                                <div class="mb-3">
+                                                    <label for="participantSort" class="form-label">Sort by:</label>
+                                                    <select id="participantSort" class="form-select form-select-sm" style="max-width:200px;">
+                                                        <option value="loyalty">Quests Joined</option>
+                                                        <option value="reliability">Reliability</option>
+                                                        <option value="questshosted">Hosted Quests</option>
+                                                        <option value="network">Network Reach</option>
+                                                    </select>
+                                                </div>
+                                                <div class="row mb-3 g-2">
+                                                    <div class="col">
+                                                        <input type="number" id="reliabilityFilter" class="form-control form-control-sm" placeholder="Min reliability %">
+                                                    </div>
+                                                    <div class="col">
+                                                        <input type="number" id="hostedFilter" class="form-control form-control-sm" placeholder="Min hosted quests">
+                                                    </div>
+                                                    <div class="col">
+                                                        <input type="number" id="networkFilter" class="form-control form-control-sm" placeholder="Min network reach">
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="table-responsive d-none" id="topParticipantsTableWrapper">
+                                                <table class="table table-striped" id="topParticipantsTable">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Participant</th>
+                                                            <th>Quests Joined</th>
+                                                            <th>Reliability</th>
+                                                            <th>Hosted Quests</th>
+                                                            <th>Network</th>
+                                                            <th>Avg Quest Rating</th>
+                                                            <th>Avg Host Rating</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody id="topParticipantsBody"></tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="headingTopCoHosts">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTopCoHosts" aria-expanded="false" aria-controls="collapseTopCoHosts">
+                                            Top 10 Co-Hosts
+                                        </button>
+                                    </h2>
+                                    <div id="collapseTopCoHosts" class="accordion-collapse collapse" aria-labelledby="headingTopCoHosts">
+                                        <div class="accordion-body">
+                                            <p id="topCoHostsEmpty" class="text-muted d-none mb-0">No co-hosts yet.</p>
+                                            <div class="table-responsive d-none" id="topCoHostsTableWrapper">
+                                                <table class="table table-striped" id="topCoHostsTable">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Co-Host</th>
+                                                            <th>Quests Co-Hosted</th>
+                                                            <th>Avg Participants</th>
+                                                            <th>Unique Participants</th>
+                                                            <th>Avg Host Rating</th>
+                                                            <th>Avg Quest Rating</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody id="topCoHostsBody"></tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -1482,6 +1166,7 @@ $(document).ready(function () {
     }
 
     $('#participantSort, #reliabilityFilter, #hostedFilter, #networkFilter').on('input change', updateParticipantTable);
+    document.addEventListener('questDashboard:participantsRendered', updateParticipantTable);
     updateParticipantTable();
 
     $(document).on('click', '.view-reviews-btn', function () {


### PR DESCRIPTION
## Summary
- convert the suggestions, quest-line, and top tabs into loading/error-aware placeholders for dynamic rendering
- add section state management plus helpers to render suggestions, quest lines, and top tables with tooltips and participant events
- hook the participant filters to the new questDashboard:participantsRendered event so filters refresh after rows load

## Testing
- php -l html/quest-giver-dashboard.php

------
https://chatgpt.com/codex/tasks/task_b_68cf1571c17c83339040d363d85f7e20