### PR TITLE
Fix quest dashboard draft status lookup

### DIFF
--- a/html/Kickback/Backend/Services/QuestDashboardService.php
+++ b/html/Kickback/Backend/Services/QuestDashboardService.php
@@ -853,7 +853,7 @@ class QuestDashboardService
                     'reviewStatus' => [
                         'published' => $line->reviewStatus->published,
                         'beingReviewed' => $line->reviewStatus->beingReviewed,
-                        'draft' => $line->reviewStatus->draft,
+                        'draft' => $line->reviewStatus->isDraft(),
                     ],
                     'counts' => [
                         'quests' => $stats['questCount'],
@@ -1088,7 +1088,7 @@ class QuestDashboardService
             'reviewStatus' => $card->reviewStatus ? [
                 'published' => $card->reviewStatus->published,
                 'beingReviewed' => $card->reviewStatus->beingReviewed,
-                'draft' => $card->reviewStatus->draft,
+                'draft' => $card->reviewStatus->isDraft(),
             ] : null,
         ];
     }


### PR DESCRIPTION
## Summary
- map quest line and card review statuses using the existing isDraft() helper instead of a missing draft property

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cf19634144833388f13801d8c9632c