### PR TITLE
Enrich quest dashboard API payload for suggestion messaging

### DIFF
--- a/html/assets/js/questGiverDashboard.js
+++ b/html/assets/js/questGiverDashboard.js
@@ -330,6 +330,12 @@
         if (!quest || typeof quest !== 'object') {
             return '#';
         }
+        if (quest.viewUrl) {
+            return quest.viewUrl;
+        }
+        if (quest.publicUrl) {
+            return quest.publicUrl;
+        }
         if (quest.url) {
             return quest.url;
         }
@@ -730,7 +736,7 @@
             $engagementCell.append($('<div class="small text-muted"></div>').text(`Attendance: ${attendanceText}`));
             $row.append($engagementCell);
 
-            const viewUrl = line.publicUrl || line.url || line.viewUrl || '';
+            const viewUrl = line.viewUrl || line.publicUrl || line.url || '';
             const $actionCell = $('<td class="text-end"></td>');
             if (isPublished && viewUrl) {
                 $actionCell.append($('<a class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener">View</a>').attr('href', viewUrl));


### PR DESCRIPTION
## Summary
- attach precomputed recommendation messages and quest URLs/banners to each dashboard suggestion
- normalize suggestion and quest line payloads for the API, exposing icon paths, public URLs, and formatted scheduling data
- teach the quest giver dashboard JavaScript to rely on the enriched URLs for suggestion cards and quest line view buttons

## Testing
- php -l html/Kickback/Backend/Services/QuestDashboardService.php

------
https://chatgpt.com/codex/tasks/task_b_68cf1c9b9fa483339177dae713985b2a