### PR TITLE
Ensure dates carry date class and tooltips

### DIFF
--- a/html/assets/js/questGiverDashboard.js
+++ b/html/assets/js/questGiverDashboard.js
@@ -283,7 +283,14 @@
 
             if (quest && quest.dateTime) {
                 const formatted = formatDateFromPayload(quest.dateTime);
-                const meta = $('<p class="text-muted small mb-2"></p>').text(formatted.text);
+                const meta = $('<p class="text-muted small mb-2"></p>');
+                const $dateSpan = $('<span class="date"></span>').text(formatted.text);
+                if (formatted.tooltip) {
+                    $dateSpan.attr('data-bs-toggle', 'tooltip')
+                        .attr('data-bs-placement', 'bottom')
+                        .attr('data-bs-title', formatted.tooltip);
+                }
+                meta.append($dateSpan);
                 bodyCol.append(meta);
             }
 
@@ -316,6 +323,7 @@
         });
 
         $list.removeClass('d-none');
+        initializeTooltips($list);
     }
 
     const suggestionDefinitions = [
@@ -404,7 +412,7 @@
             rel: 'noopener',
             text: questTitle
         });
-        const $runSpan = $('<span></span>').text(runInfo.text || 'date TBD');
+        const $runSpan = $('<span class="date"></span>').text(runInfo.text || 'date TBD');
         if (runInfo.tooltip) {
             $runSpan.attr('data-bs-toggle', 'tooltip')
                 .attr('data-bs-placement', 'bottom')
@@ -530,7 +538,7 @@
                     $lastQuestCell.text(`${days} day${days === 1 ? '' : 's'} ago`);
                 } else if (candidate.lastQuest && typeof candidate.lastQuest === 'object') {
                     const lastInfo = formatDateFromPayload(candidate.lastQuest);
-                    const $lastSpan = $('<span></span>').text(lastInfo.text || '—');
+                    const $lastSpan = $('<span class="date"></span>').text(lastInfo.text || '—');
                     if (lastInfo.tooltip) {
                         $lastSpan.attr('data-bs-toggle', 'tooltip')
                             .attr('data-bs-placement', 'bottom')
@@ -664,7 +672,7 @@
             if (futureCount > 0) {
                 if (line.nextRun) {
                     const nextInfo = formatDateFromPayload(line.nextRun);
-                    const $nextSpan = $('<span></span>').text(nextInfo.text);
+                    const $nextSpan = $('<span class="date"></span>').text(nextInfo.text);
                     if (nextInfo.tooltip) {
                         $nextSpan.attr('data-bs-toggle', 'tooltip')
                             .attr('data-bs-placement', 'bottom')
@@ -682,7 +690,7 @@
             const $lastLine = $('<div><strong>Last:</strong> </div>');
             if (line.lastRun) {
                 const lastInfo = formatDateFromPayload(line.lastRun);
-                const $lastSpan = $('<span></span>').text(lastInfo.text);
+                const $lastSpan = $('<span class="date"></span>').text(lastInfo.text);
                 if (lastInfo.tooltip) {
                     $lastSpan.attr('data-bs-toggle', 'tooltip')
                         .attr('data-bs-placement', 'bottom')

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -844,7 +844,8 @@ $(document).ready(function () {
                     if (idx === 0) {
                         left.append('<span class="badge bg-success me-2">Next quest</span>');
                     }
-                    left.append($('<strong></strong>').text(formatted));
+                    const dateSpan = $('<span class="date"></span>').text(formatted);
+                    left.append($('<strong></strong>').append(dateSpan));
                     header.append(left);
                     if (typeof item.score !== 'undefined') {
                         header.append($('<span class="badge bg-primary"></span>').text(item.score));


### PR DESCRIPTION
## Summary
- ensure upcoming quest cards wrap their date text in `.date` spans and initialize tooltips
- add the `.date` class to suggestion, co-host, and quest line date spans while preserving tooltip metadata
- wrap suggested calendar dates in the dashboard PHP markup with a `.date` span for consistent styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cf211814d8833398821ceaa9acaad8