### PR TITLE
Filter unpublished quests from community calendar feed

### DIFF
--- a/html/Kickback/Backend/Controllers/ScheduleController.php
+++ b/html/Kickback/Backend/Controllers/ScheduleController.php
@@ -64,7 +64,9 @@ class ScheduleController
                     . "FROM quest q "
                     . "JOIN account a ON a.Id = q.host_id "
                     . "LEFT JOIN quest_applicants qa ON qa.quest_id = q.Id AND qa.participated = 1 "
-                    . "WHERE MONTH(q.end_date) = ? AND YEAR(q.end_date) = ? AND q.raffle_id IS NULL "
+                    . "WHERE MONTH(q.end_date) = ? AND YEAR(q.end_date) = ? "
+                    . "AND q.published = 1 "
+                    . "AND q.raffle_id IS NULL "
                     . "GROUP BY q.Id";
                 $stmt2 = mysqli_prepare($db, $questQuery);
                 if ($stmt2) {


### PR DESCRIPTION
## Summary
- ensure the include-all calendar query filters to published quests before merging community events
- keep personal calendar queries unchanged so drafts remain visible to their authors

## Testing
- php -l html/Kickback/Backend/Controllers/ScheduleController.php

------
https://chatgpt.com/codex/tasks/task_b_68cf243e3c808333be7fca94473bb36d