### PR TITLE
Ensure review inbox tooltips refresh

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -943,6 +943,16 @@ $(document).ready(function () {
         }, 'json');
     });
 
+    function initReviewInboxTooltips() {
+        $('#datatable-review-inbox [data-bs-toggle="tooltip"]').each(function () {
+            const tooltip = bootstrap.Tooltip.getInstance(this);
+            if (tooltip) {
+                tooltip.dispose();
+            }
+            new bootstrap.Tooltip(this);
+        });
+    }
+
     function loadReviewInbox() {
         if ($.fn.DataTable.isDataTable('#datatable-review-inbox')) {
             $('#datatable-review-inbox').DataTable().destroy();
@@ -1005,11 +1015,16 @@ $(document).ready(function () {
                     }
                 });
 
+                initReviewInboxTooltips();
+
                 $('#datatable-review-inbox').DataTable({
                     pageLength: 10,
                     lengthChange: true,
                     order: [[2, 'desc']],
-                    columnDefs: [{ targets: [3], orderable: false }]
+                    columnDefs: [{ targets: [3], orderable: false }],
+                    drawCallback: function () {
+                        initReviewInboxTooltips();
+                    }
                 });
             } else {
                 $('#datatable-review-inbox tbody').html('<tr><td colspan="4" class="text-danger">' + resp.message + '</td></tr>');


### PR DESCRIPTION
## Summary
- add a helper to rebuild review inbox tooltips and dispose any existing instances
- call the helper after loading inbox rows and on DataTables draw callbacks to keep tooltips working

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cf27aa062483339771baffacc50b45