### PR TITLE
Add score-driven ranking to quest giver co-host leaderboard

### DIFF
--- a/html/assets/js/questGiverDashboard.js
+++ b/html/assets/js/questGiverDashboard.js
@@ -954,6 +954,9 @@
                 $hostCell.append($hostWrap);
                 $row.append($hostCell);
 
+                const score = Number(host.score);
+                $row.append($('<td class="align-middle fw-semibold"></td>').text(Number.isFinite(score) ? score.toFixed(1) : '—'));
+
                 const questCount = Number(host.questCount);
                 $row.append($('<td class="align-middle"></td>').text(Number.isFinite(questCount) ? questCount.toLocaleString() : '—'));
 

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -534,6 +534,7 @@ $account = Session::getCurrentAccount();
                                                         <thead>
                                                             <tr>
                                                                 <th>Co-Host</th>
+                                                                <th>Score</th>
                                                                 <th>Quests Co-Hosted</th>
                                                                 <th>Avg Participants</th>
                                                                 <th>Unique Participants</th>


### PR DESCRIPTION
## Summary
- add a weighted score for co-host stats and limit the leaderboard to the top 10 entries
- expose the score in the API payload and render it in the quest giver dashboard table

## Testing
- php -l html/Kickback/Backend/Services/QuestDashboardService.php

------
https://chatgpt.com/codex/tasks/task_b_68cf290668dc8333985f1749cb588437