### PR TITLE
Remove unused moment.js dependency

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -574,7 +574,6 @@ $account = Session::getCurrentAccount();
     <?php require("php-components/base-page-footer.php"); ?>
 </main>
 <?php require("php-components/base-page-javascript.php"); ?>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js"></script>
 <script>
 window.questDashboardConfig = Object.assign({}, window.questDashboardConfig || {}, {


### PR DESCRIPTION
## Summary
- remove the unused moment.js script from the quest giver dashboard markup
- verify that all inline scripts already rely on native Date APIs for formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cf2ae8e4148333b5fbf327795587b4