### PR TITLE
Guard suggested dates response

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -849,7 +849,7 @@ $(document).ready(function () {
         $.post('/api/v1/schedule/suggestedDates.php', { sessionToken: sessionToken, month: calMonth + 1, year: calYear }, function(resp) {
             const list = $('#suggestedDatesList');
             list.empty();
-            if (resp && resp.success && resp.data.length) {
+            if (resp && resp.success && Array.isArray(resp.data) && resp.data.length) {
                 resp.data.forEach(function(item, idx) {
                     const [y, m, d] = item.date.split('-').map(Number);
                     const dateObj = new Date(y, m - 1, d);
@@ -880,6 +880,9 @@ $(document).ready(function () {
                     list.append(li);
                 });
             } else {
+                if (resp && resp.success && !Array.isArray(resp.data)) {
+                    console.error('Suggested dates response data was not an array.', resp.data);
+                }
                 list.append('<li class="list-group-item">No suggestions available</li>');
             }
         }, 'json');


### PR DESCRIPTION
## Summary
- ensure suggested dates API data is an array before rendering
- log an error when the API succeeds but returns a non-array payload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cf2b38aa448333ad36b1cf88364d54