### PR TITLE
Remove duplicate escapeHtml helper override

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1035,10 +1035,6 @@ $(document).ready(function () {
         }, 'json');
     }
 
-    function escapeHtml(str) {
-        return $('<div>').text(str ?? '').html();
-    }
-
     function resetCloneAlert() {
         const alertBox = $('#questCloneAlert');
         if (cloneAlertTimeout) {


### PR DESCRIPTION
## Summary
- keep a single escapeHtml helper that escapes &, <, >, " and ' for tooltip and alert HTML
- remove the later jQuery-based escapeHtml override so attribute-safe output remains consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cf2bc39a108333b91f9fdf0f77bfbf