### PR TITLE
Escape review error messages

### DIFF
--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1030,7 +1030,15 @@ $(document).ready(function () {
                     }
                 });
             } else {
-                $('#datatable-review-inbox tbody').html('<tr><td colspan="4" class="text-danger">' + resp.message + '</td></tr>');
+                const tbody = $('#datatable-review-inbox tbody');
+                tbody.empty();
+                const errorRow = $('<tr></tr>');
+                const errorCell = $('<td></td>')
+                    .attr('colspan', 4)
+                    .addClass('text-danger')
+                    .text(resp.message || 'Failed to load review inbox.');
+                errorRow.append(errorCell);
+                tbody.append(errorRow);
             }
         }, 'json');
     }
@@ -1194,7 +1202,9 @@ $(document).ready(function () {
                 });
                 $('#reviewModalBody').html(list);
             } else {
-                $('#reviewModalBody').html('<div class="text-danger">' + resp.message + '</div>');
+                const errorMessage = resp.message || 'Failed to load quest reviews.';
+                const errorContent = $('<div></div>').addClass('text-danger').text(errorMessage);
+                $('#reviewModalBody').empty().append(errorContent);
             }
         }, 'json');
     });


### PR DESCRIPTION
## Summary
- build the review inbox error row with text nodes so API messages render safely
- update the review modal failure state to inject plain text with a fallback copy

## Testing
- php -l html/quest-giver-dashboard.php
- php -r '$dom = new DOMDocument(); $cell = $dom->createElement("td"); $cell->setAttribute("colspan", "4"); $cell->setAttribute("class", "text-danger"); $message = "Invalid session token <img src=x onerror=alert(1) />"; $cell->appendChild($dom->createTextNode($message)); echo $dom->saveHTML($cell), PHP_EOL;'
- php -r '$dom = new DOMDocument(); $div = $dom->createElement("div"); $div->setAttribute("class", "text-danger"); $message = "Invalid session token <img src=x onerror=alert(1) />"; $div->appendChild($dom->createTextNode($message)); echo $dom->saveHTML($div), PHP_EOL;'


------
https://chatgpt.com/codex/tasks/task_b_68cf2c457d808333a0d6775cc7593a3c