### PR TITLE
Fix Chart.js time scale adapter error

### DIFF
--- a/html/analytics.php
+++ b/html/analytics.php
@@ -248,7 +248,8 @@ $mapDataJSON = json_encode($mapData);
 
     
     <?php require("php-components/base-page-javascript.php"); ?>
-    
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js"></script>
 
     <script src="https://code.highcharts.com/maps/highmaps.js"></script>

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -571,9 +571,10 @@ $account = Session::getCurrentAccount();
         </div>
     </div>
 
-    <?php require("php-components/base-page-footer.php"); ?>
+<?php require("php-components/base-page-footer.php"); ?>
 </main>
 <?php require("php-components/base-page-javascript.php"); ?>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js"></script>
 <script>
 window.questDashboardConfig = Object.assign({}, window.questDashboardConfig || {}, {


### PR DESCRIPTION
## Summary
- load Moment.js on pages that render time-based Chart.js graphs
- ensure Chart.js has a date adapter available so dashboards initialize without runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cf2d4d876883339e63424b4c237056