### PR TITLE
Add player card popovers to username links

### DIFF
--- a/html/Kickback/Backend/Views/vAccount.php
+++ b/html/Kickback/Backend/Views/vAccount.php
@@ -108,7 +108,10 @@ class vAccount extends vRecordId
     }
 
     public function getAccountElement() : string {
-        return '<a href="'.$this->url().'" class="username">'.$this->username.'</a>';
+        $username = htmlspecialchars($this->username, ENT_QUOTES, 'UTF-8');
+        $accountId = htmlspecialchars((string)$this->crand, ENT_QUOTES, 'UTF-8');
+
+        return '<a href="'.$this->url().'" class="username" data-account-id="'.$accountId.'" data-username="'.$username.'">'.$username.'</a>';
     }
 
     public function getAccountTitle() : string {

--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -148,12 +148,14 @@ body {
 .popover.player-card-popover .player-card {
     margin: 0;
     box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
+    position: relative;
+    overflow: visible;
 }
 
 .popover.player-card-popover .popover-arrow {
     width: calc(var(--player-card-popover-arrow-size) * 2);
     height: calc(var(--player-card-popover-arrow-size) * 2);
-    filter: drop-shadow(0 0.35rem 0.9rem var(--player-card-popover-arrow-shadow));
+    opacity: 0;
 }
 
 .popover.player-card-popover .popover-arrow::before,
@@ -162,6 +164,18 @@ body {
     content: "";
     border-style: solid;
     border-color: transparent;
+}
+
+.popover.player-card-popover .player-card::before,
+.popover.player-card-popover .player-card::after {
+    content: "";
+    position: absolute;
+    display: none;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-color: transparent;
+    pointer-events: none;
 }
 
 .popover.player-card-popover[data-popper-placement^="top"] > .popover-arrow::before,
@@ -176,6 +190,24 @@ body {
 
 .popover.player-card-popover[data-popper-placement^="top"] > .popover-arrow::after {
     bottom: 1px;
+    border-top-color: var(--player-card-popover-arrow-bg);
+}
+
+.popover.player-card-popover[data-popper-placement^="top"] .player-card::before,
+.popover.player-card-popover[data-popper-placement^="top"] .player-card::after {
+    display: block;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size) 0;
+}
+
+.popover.player-card-popover[data-popper-placement^="top"] .player-card::before {
+    bottom: calc(-1 * var(--player-card-popover-arrow-size));
+    border-top-color: var(--player-card-popover-arrow-shadow);
+}
+
+.popover.player-card-popover[data-popper-placement^="top"] .player-card::after {
+    bottom: calc(-1 * var(--player-card-popover-arrow-size) + 1px);
     border-top-color: var(--player-card-popover-arrow-bg);
 }
 
@@ -194,6 +226,24 @@ body {
     border-bottom-color: var(--player-card-popover-arrow-bg);
 }
 
+.popover.player-card-popover[data-popper-placement^="bottom"] .player-card::before,
+.popover.player-card-popover[data-popper-placement^="bottom"] .player-card::after {
+    display: block;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 0 var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size);
+}
+
+.popover.player-card-popover[data-popper-placement^="bottom"] .player-card::before {
+    top: calc(-1 * var(--player-card-popover-arrow-size));
+    border-bottom-color: var(--player-card-popover-arrow-shadow);
+}
+
+.popover.player-card-popover[data-popper-placement^="bottom"] .player-card::after {
+    top: calc(-1 * var(--player-card-popover-arrow-size) + 1px);
+    border-bottom-color: var(--player-card-popover-arrow-bg);
+}
+
 .popover.player-card-popover[data-popper-placement^="left"] > .popover-arrow::before,
 .popover.player-card-popover[data-popper-placement^="left"] > .popover-arrow::after {
     border-width: var(--player-card-popover-arrow-size) 0 var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size);
@@ -209,6 +259,24 @@ body {
     border-left-color: var(--player-card-popover-arrow-bg);
 }
 
+.popover.player-card-popover[data-popper-placement^="left"] .player-card::before,
+.popover.player-card-popover[data-popper-placement^="left"] .player-card::after {
+    display: block;
+    top: 50%;
+    transform: translateY(-50%);
+    border-width: var(--player-card-popover-arrow-size) 0 var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size);
+}
+
+.popover.player-card-popover[data-popper-placement^="left"] .player-card::before {
+    right: calc(-1 * var(--player-card-popover-arrow-size));
+    border-left-color: var(--player-card-popover-arrow-shadow);
+}
+
+.popover.player-card-popover[data-popper-placement^="left"] .player-card::after {
+    right: calc(-1 * var(--player-card-popover-arrow-size) + 1px);
+    border-left-color: var(--player-card-popover-arrow-bg);
+}
+
 .popover.player-card-popover[data-popper-placement^="right"] > .popover-arrow::before,
 .popover.player-card-popover[data-popper-placement^="right"] > .popover-arrow::after {
     border-width: var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size) 0;
@@ -221,6 +289,24 @@ body {
 
 .popover.player-card-popover[data-popper-placement^="right"] > .popover-arrow::after {
     left: 1px;
+    border-right-color: var(--player-card-popover-arrow-bg);
+}
+
+.popover.player-card-popover[data-popper-placement^="right"] .player-card::before,
+.popover.player-card-popover[data-popper-placement^="right"] .player-card::after {
+    display: block;
+    top: 50%;
+    transform: translateY(-50%);
+    border-width: var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size) 0;
+}
+
+.popover.player-card-popover[data-popper-placement^="right"] .player-card::before {
+    left: calc(-1 * var(--player-card-popover-arrow-size));
+    border-right-color: var(--player-card-popover-arrow-shadow);
+}
+
+.popover.player-card-popover[data-popper-placement^="right"] .player-card::after {
+    left: calc(-1 * var(--player-card-popover-arrow-size) + 1px);
     border-right-color: var(--player-card-popover-arrow-bg);
 }
 

--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -129,6 +129,9 @@ body {
 
 .popover.player-card-popover {
     --bs-popover-max-width: 9999px;
+    --player-card-popover-arrow-size: 0.75rem;
+    --player-card-popover-arrow-bg: var(--bs-card-bg, #fff);
+    --player-card-popover-arrow-shadow: rgba(0, 0, 0, 0.45);
     max-width: none;
     width: auto;
     padding: 0;
@@ -147,9 +150,78 @@ body {
     box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
 }
 
+.popover.player-card-popover .popover-arrow {
+    width: calc(var(--player-card-popover-arrow-size) * 2);
+    height: calc(var(--player-card-popover-arrow-size) * 2);
+    filter: drop-shadow(0 0.35rem 0.9rem var(--player-card-popover-arrow-shadow));
+}
+
 .popover.player-card-popover .popover-arrow::before,
 .popover.player-card-popover .popover-arrow::after {
-    display: none;
+    display: block;
+    content: "";
+    border-style: solid;
+    border-color: transparent;
+}
+
+.popover.player-card-popover[data-popper-placement^="top"] > .popover-arrow::before,
+.popover.player-card-popover[data-popper-placement^="top"] > .popover-arrow::after {
+    border-width: var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size) 0;
+}
+
+.popover.player-card-popover[data-popper-placement^="top"] > .popover-arrow::before {
+    bottom: 0;
+    border-top-color: var(--player-card-popover-arrow-shadow);
+}
+
+.popover.player-card-popover[data-popper-placement^="top"] > .popover-arrow::after {
+    bottom: 1px;
+    border-top-color: var(--player-card-popover-arrow-bg);
+}
+
+.popover.player-card-popover[data-popper-placement^="bottom"] > .popover-arrow::before,
+.popover.player-card-popover[data-popper-placement^="bottom"] > .popover-arrow::after {
+    border-width: 0 var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size);
+}
+
+.popover.player-card-popover[data-popper-placement^="bottom"] > .popover-arrow::before {
+    top: 0;
+    border-bottom-color: var(--player-card-popover-arrow-shadow);
+}
+
+.popover.player-card-popover[data-popper-placement^="bottom"] > .popover-arrow::after {
+    top: 1px;
+    border-bottom-color: var(--player-card-popover-arrow-bg);
+}
+
+.popover.player-card-popover[data-popper-placement^="left"] > .popover-arrow::before,
+.popover.player-card-popover[data-popper-placement^="left"] > .popover-arrow::after {
+    border-width: var(--player-card-popover-arrow-size) 0 var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size);
+}
+
+.popover.player-card-popover[data-popper-placement^="left"] > .popover-arrow::before {
+    right: 0;
+    border-left-color: var(--player-card-popover-arrow-shadow);
+}
+
+.popover.player-card-popover[data-popper-placement^="left"] > .popover-arrow::after {
+    right: 1px;
+    border-left-color: var(--player-card-popover-arrow-bg);
+}
+
+.popover.player-card-popover[data-popper-placement^="right"] > .popover-arrow::before,
+.popover.player-card-popover[data-popper-placement^="right"] > .popover-arrow::after {
+    border-width: var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size) var(--player-card-popover-arrow-size) 0;
+}
+
+.popover.player-card-popover[data-popper-placement^="right"] > .popover-arrow::before {
+    left: 0;
+    border-right-color: var(--player-card-popover-arrow-shadow);
+}
+
+.popover.player-card-popover[data-popper-placement^="right"] > .popover-arrow::after {
+    left: 1px;
+    border-right-color: var(--player-card-popover-arrow-bg);
 }
 
 .league {

--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -128,14 +128,24 @@ body {
 }
 
 .popover.player-card-popover {
+    --bs-popover-max-width: 9999px;
     max-width: none;
+    width: auto;
     padding: 0;
+    border: none;
+    background-color: transparent;
     box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
     z-index: 1080;
 }
 
 .popover.player-card-popover .popover-body {
     padding: 0;
+    background-color: transparent;
+}
+
+.popover.player-card-popover .popover-arrow::before,
+.popover.player-card-popover .popover-arrow::after {
+    display: none;
 }
 
 .league {

--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -137,6 +137,7 @@ body {
     padding: 0;
     border: none;
     background-color: transparent;
+    pointer-events: auto;
     z-index: 1080;
 }
 

--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -134,13 +134,17 @@ body {
     padding: 0;
     border: none;
     background-color: transparent;
-    box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
     z-index: 1080;
 }
 
 .popover.player-card-popover .popover-body {
     padding: 0;
     background-color: transparent;
+}
+
+.popover.player-card-popover .player-card {
+    margin: 0;
+    box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
 }
 
 .popover.player-card-popover .popover-arrow::before,

--- a/html/assets/css/kickback-kingdom.css
+++ b/html/assets/css/kickback-kingdom.css
@@ -127,6 +127,17 @@ body {
     text-decoration: none;
 }
 
+.popover.player-card-popover {
+    max-width: none;
+    padding: 0;
+    box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
+    z-index: 1080;
+}
+
+.popover.player-card-popover .popover-body {
+    padding: 0;
+}
+
 .league {
     background-color: var(--bs-primary);
     border-radius: 5px;

--- a/html/game.php
+++ b/html/game.php
@@ -454,6 +454,9 @@ $gameQuests = $gameQuestsResp->data->items;
 
                     for (const [teamName, players] of Object.entries(rowData.teams)) {
                         players.forEach(player => {
+                            const accountId = player.accountId ?? player.account_id ?? player.crand ?? '';
+                            const accountIdAttr = String(accountId ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                            const usernameAttr = (player.username ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
                             const eloChange = player.match_stats[rowData.crand].eloChange;
                             const result = eloChange > 0 ? 'Win' : 'Loss';
                             const rowClass = eloChange > 0 ? 'table-success' : 'table-danger';
@@ -462,7 +465,7 @@ $gameQuests = $gameQuestsResp->data->items;
                                 `<td>
                                     <div class="d-flex align-items-center">
                                         <img src="${player.avatar.url}" alt="${player.username}" class="me-2" style="width: 40px; height: 40px;">
-                                        <a href="/u/${player.username}" class="username">${player.username}</a>
+                                        <a href="/u/${player.username}" class="username" data-account-id="${accountIdAttr}" data-username="${usernameAttr}">${player.username}</a>
                                     </div>
                                 </td>` +
                                 `<td>${teamName}</td>` +

--- a/html/lich-landing.php
+++ b/html/lich-landing.php
@@ -174,19 +174,19 @@ use Kickback\Common\Version;
                             <div class="col-md-4 text-center">
                                 <blockquote class="blockquote">
                                     <p>"Lich's creative card game mechanics combined with an active board state scratched an itch for me I didn't even know was there!"</p>
-                                    <footer class="blockquote-footer"><a href="/u/devon%20:)" class="username">devon :)</a></footer>
+                                    <footer class="blockquote-footer"><a href="/u/devon%20:)" class="username" data-account-id="" data-username="devon :)">devon :)</a></footer>
                                 </blockquote>
                             </div>
                             <div class="col-md-4 text-center">
                                 <blockquote class="blockquote">
                                     <p>"L.I.C.H. is a game with a lot of potential and can be a lot of fun with friends."</p>
-                                    <footer class="blockquote-footer"><a href="/u/Kotojo" class="username">Kotojo</a></footer>
+                                    <footer class="blockquote-footer"><a href="/u/Kotojo" class="username" data-account-id="" data-username="Kotojo">Kotojo</a></footer>
                                 </blockquote>
                             </div>
                             <div class="col-md-4 text-center">
                                 <blockquote class="blockquote">
                                     <p>"The synergy between your cards and abilities is endlessly satisfying, and the dynamic board interactivity keeps every match fresh and engaging."</p>
-                                    <footer class="blockquote-footer"><a href="/u/LandoTheBarbarian" class="username">LandoTheBarbarian</a></footer>
+                                    <footer class="blockquote-footer"><a href="/u/LandoTheBarbarian" class="username" data-account-id="" data-username="LandoTheBarbarian">LandoTheBarbarian</a></footer>
                                 </blockquote>
                             </div>
                         </div>

--- a/html/php-components/base-page-components.php
+++ b/html/php-components/base-page-components.php
@@ -345,8 +345,8 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                                                 <h5 class="card-title" id="quest-review-quest-title">Cpt. Longs' Barothon (Continued)</h5>
                                             </a>
                                             <p class="card-text">
-                                                <small class="text-body-secondary">Hosted by <a id="quest-review-quest-host-1" href="/beta/u/hansibaba" class="username">hansibaba</a>
-                                                <span id="quest-review-quest-host-2-span">and <a id="quest-review-quest-host-2" href="/beta/u/hansibaba" class="username">hansibaba</a></span>
+                                                <small class="text-body-secondary">Hosted by <a id="quest-review-quest-host-1" href="/beta/u/hansibaba" class="username" data-account-id="" data-username="hansibaba">hansibaba</a>
+                                                <span id="quest-review-quest-host-2-span">and <a id="quest-review-quest-host-2" href="/beta/u/hansibaba" class="username" data-account-id="" data-username="hansibaba">hansibaba</a></span>
                                                                                     on <span id="quest-review-quest-date" class="date">Jul 21, 2023</span>
                                                 </small>
                                             </p>
@@ -525,7 +525,7 @@ $totalUnclaimedTasks = $unclaimedRecurringCount + $unclaimedAchievementsCount;
                             <img id="inventoryItemImage" src="" class="img-fluid animate__animated" alt="Item Image" style="width: 100%;">
                             <img id="inventoryItemImageSecondary" src="" class="img-fluid animate__animated" alt="Item Image" style="width: 100%; display: none;">
                         </div>
-                        <p class="float-end" style="font-size: .8em;">Artwork by <a class="username" id="inventoryItemArtist" href="#">Artist: Artist Name</a></p>
+                        <p class="float-end" style="font-size: .8em;">Artwork by <a class="username" id="inventoryItemArtist" href="#" data-account-id="" data-username="Artist: Artist Name">Artist: Artist Name</a></p>
                     </div>
                     <div class="col-12 col-md-6">
                         

--- a/html/php-components/base-page-javascript.php
+++ b/html/php-components/base-page-javascript.php
@@ -156,6 +156,10 @@ use Kickback\Common\Version;
         (function() {
             const USERNAME_SELECTOR = '.username';
             const BOUND_FLAG = 'playerCardPopoverBound';
+            // Delay popover dismissal so users have time to move from the trigger
+            // toward the floating card without it collapsing mid-flight.
+            const SHOW_DELAY = 150;
+            const HIDE_DELAY = 500;
             const accountCacheByUsername = new Map();
             const accountCacheById = new Map();
             const pendingRequests = new Map();
@@ -345,7 +349,7 @@ use Kickback\Common\Version;
                             popover.show();
                         }
                     });
-                }, 150);
+                }, SHOW_DELAY);
 
                 showTimers.set(element, timerId);
             }
@@ -370,7 +374,7 @@ use Kickback\Common\Version;
 
                         popover.hide();
                     }
-                }, 200);
+                }, HIDE_DELAY);
 
                 hideTimers.set(element, timerId);
             }

--- a/html/php-components/base-page-javascript.php
+++ b/html/php-components/base-page-javascript.php
@@ -363,7 +363,7 @@ use Kickback\Common\Version;
                     const popover = popoverInstances.get(element);
                     if (popover) {
                         const tipElement = typeof popover.getTipElement === 'function' ? popover.getTipElement() : null;
-                        if (tipElement && tipElement.matches(':hover')) {
+                        if (tipElement && (tipElement.matches(':hover') || tipElement.matches(':focus-within'))) {
                             state.popoverHovered = true;
                             return;
                         }
@@ -471,16 +471,27 @@ use Kickback\Common\Version;
                         state.popoverHovered = false;
                         scheduleHide(element);
                     };
+                    const handleOver = event => {
+                        if (tipElement.contains(event.target)) {
+                            handleEnter();
+                        }
+                    };
+                    const handleOut = event => {
+                        const nextTarget = event.relatedTarget;
+                        if (nextTarget && tipElement.contains(nextTarget)) {
+                            return;
+                        }
+                        handleLeave();
+                    };
 
                     tipElement.addEventListener('mouseenter', handleEnter);
                     tipElement.addEventListener('mouseleave', handleLeave);
+                    tipElement.addEventListener('mouseover', handleOver);
+                    tipElement.addEventListener('mouseout', handleOut);
+                    tipElement.addEventListener('pointerenter', handleEnter);
+                    tipElement.addEventListener('pointerleave', handleLeave);
                     tipElement.addEventListener('focusin', handleEnter);
-                    tipElement.addEventListener('focusout', event => {
-                        const nextTarget = event.relatedTarget;
-                        if (!nextTarget || !tipElement.contains(nextTarget)) {
-                            handleLeave();
-                        }
-                    });
+                    tipElement.addEventListener('focusout', handleOut);
                     tipElement.dataset.playerCardPopoverBound = 'true';
                 }
 

--- a/html/php-components/base-page-javascript.php
+++ b/html/php-components/base-page-javascript.php
@@ -142,10 +142,16 @@ use Kickback\Common\Version;
         }
 
         const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
-        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+        const tooltipList = [];
+        Array.prototype.forEach.call(tooltipTriggerList, function(tooltipTriggerEl) {
+            tooltipList.push(new bootstrap.Tooltip(tooltipTriggerEl));
+        });
 
-        const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]')
-        const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
+        const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]');
+        const popoverList = [];
+        Array.prototype.forEach.call(popoverTriggerList, function(popoverTriggerEl) {
+            popoverList.push(new bootstrap.Popover(popoverTriggerEl));
+        });
 
         (function() {
             const USERNAME_SELECTOR = '.username';

--- a/html/php-components/base-page-javascript.php
+++ b/html/php-components/base-page-javascript.php
@@ -427,10 +427,19 @@ use Kickback\Common\Version;
                     popoverInstances.set(element, popover);
 
                     element.addEventListener('shown.bs.popover', () => handlePopoverShown(element));
-                    element.addEventListener('hide.bs.popover', () => {
+                    element.addEventListener('hide.bs.popover', event => {
+                        const state = getHoverState(element);
+                        const tipElement = typeof popover.getTipElement === 'function' ? popover.getTipElement() : null;
+                        const shouldKeepOpen = state.triggerHovered || state.popoverHovered ||
+                            (tipElement && (tipElement.matches(':hover') || tipElement.matches(':focus-within')));
+
+                        if (shouldKeepOpen) {
+                            event.preventDefault();
+                            return;
+                        }
+
                         clearTimer(showTimers, element);
                         clearTimer(hideTimers, element);
-                        const state = getHoverState(element);
                         state.triggerHovered = false;
                         state.popoverHovered = false;
                     });

--- a/html/php-components/base-page-javascript.php
+++ b/html/php-components/base-page-javascript.php
@@ -169,6 +169,26 @@ use Kickback\Common\Version;
             const supportsHover = window.matchMedia ? window.matchMedia('(hover: hover)').matches : false;
             const hoverStates = new WeakMap();
 
+            function isElementHovered(element) {
+                if (!element) {
+                    return false;
+                }
+
+                if (element.matches(':hover')) {
+                    return true;
+                }
+
+                const hoveredElements = document.querySelectorAll(':hover');
+                for (let i = hoveredElements.length - 1; i >= 0; i--) {
+                    const hovered = hoveredElements[i];
+                    if (hovered === element || element.contains(hovered)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             function getHoverState(element) {
                 let state = hoverStates.get(element);
                 if (!state) {
@@ -367,8 +387,9 @@ use Kickback\Common\Version;
                     const popover = popoverInstances.get(element);
                     if (popover) {
                         const tipElement = typeof popover.getTipElement === 'function' ? popover.getTipElement() : null;
-                        if (tipElement && (tipElement.matches(':hover') || tipElement.matches(':focus-within'))) {
+                        if (tipElement && (isElementHovered(tipElement) || tipElement.matches(':focus-within'))) {
                             state.popoverHovered = true;
+                            clearTimer(hideTimers, element);
                             return;
                         }
 
@@ -481,6 +502,10 @@ use Kickback\Common\Version;
                         clearTimer(hideTimers, element);
                     };
                     const handleLeave = () => {
+                        if (isElementHovered(tipElement)) {
+                            return;
+                        }
+
                         state.popoverHovered = false;
                         scheduleHide(element);
                     };
@@ -508,7 +533,7 @@ use Kickback\Common\Version;
                     tipElement.dataset.playerCardPopoverBound = 'true';
                 }
 
-                if (tipElement.matches(':hover')) {
+                if (isElementHovered(tipElement)) {
                     const state = getHoverState(element);
                     state.popoverHovered = true;
                     clearTimer(hideTimers, element);

--- a/html/php-components/base-page-javascript.php
+++ b/html/php-components/base-page-javascript.php
@@ -147,6 +147,395 @@ use Kickback\Common\Version;
         const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]')
         const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
 
+        (function() {
+            const USERNAME_SELECTOR = '.username';
+            const BOUND_FLAG = 'playerCardPopoverBound';
+            const accountCacheByUsername = new Map();
+            const accountCacheById = new Map();
+            const pendingRequests = new Map();
+            const popoverInstances = new WeakMap();
+            const showTimers = new WeakMap();
+            const hideTimers = new WeakMap();
+            const supportsHover = window.matchMedia ? window.matchMedia('(hover: hover)').matches : false;
+
+            function normalize(value) {
+                if (value === undefined || value === null) {
+                    return '';
+                }
+
+                return String(value).trim();
+            }
+
+            function normalizeUsername(value) {
+                return normalize(value).toLowerCase();
+            }
+
+            function decodeEntities(value) {
+                if (!value || value.indexOf('&') === -1) {
+                    return value;
+                }
+
+                const textarea = decodeEntities.textarea || (decodeEntities.textarea = document.createElement('textarea'));
+                textarea.innerHTML = value;
+                return textarea.value;
+            }
+
+            function cacheAccount(account) {
+                if (!account || typeof account !== 'object') {
+                    return null;
+                }
+
+                const username = normalize(account.username ?? '');
+                const accountId = normalize(account.crand ?? account.accountId ?? account.account_id ?? '');
+
+                if (username) {
+                    accountCacheByUsername.set(normalizeUsername(username), account);
+                }
+
+                if (accountId) {
+                    accountCacheById.set(accountId, account);
+                }
+
+                return account;
+            }
+
+            function getCachedAccount(username, accountId) {
+                const normalizedId = normalize(accountId);
+                if (normalizedId && accountCacheById.has(normalizedId)) {
+                    return accountCacheById.get(normalizedId);
+                }
+
+                const normalizedUsername = normalizeUsername(username);
+                if (normalizedUsername && accountCacheByUsername.has(normalizedUsername)) {
+                    return accountCacheByUsername.get(normalizedUsername);
+                }
+
+                return null;
+            }
+
+            function getElementUsername(element) {
+                const datasetUsername = normalize(element.dataset.username ?? '');
+                if (datasetUsername) {
+                    return normalize(decodeEntities(datasetUsername));
+                }
+
+                return normalize(element.textContent ?? '');
+            }
+
+            function getElementAccountId(element) {
+                const datasetAccountId = normalize(element.dataset.accountId ?? '');
+                if (datasetAccountId) {
+                    return normalize(decodeEntities(datasetAccountId));
+                }
+
+                return null;
+            }
+
+            function getRequestKey(username, accountId) {
+                const normalizedId = normalize(accountId);
+                if (normalizedId) {
+                    return `id:${normalizedId}`;
+                }
+
+                const normalizedUsername = normalizeUsername(username);
+                if (normalizedUsername) {
+                    return `user:${normalizedUsername}`;
+                }
+
+                return null;
+            }
+
+            function fetchAccountData(searchTerm) {
+                const params = new URLSearchParams();
+                params.append('searchTerm', searchTerm);
+                params.append('page', '1');
+                params.append('itemsPerPage', '1');
+
+                return fetch('/api/v1/account/search.php?json', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: params
+                })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data && data.success && data.data && Array.isArray(data.data.accountItems) && data.data.accountItems.length > 0) {
+                            return cacheAccount(data.data.accountItems[0]);
+                        }
+
+                        return null;
+                    })
+                    .catch(error => {
+                        console.error('Failed to load account information for player card popover.', error);
+                        return null;
+                    });
+            }
+
+            function requestAccount(element) {
+                const username = getElementUsername(element);
+                const accountId = getElementAccountId(element);
+
+                const cached = getCachedAccount(username, accountId);
+                if (cached) {
+                    return Promise.resolve(cached);
+                }
+
+                const searchTerm = username || accountId;
+                if (!searchTerm) {
+                    return Promise.resolve(null);
+                }
+
+                const requestKey = getRequestKey(username, accountId);
+                if (requestKey && pendingRequests.has(requestKey)) {
+                    return pendingRequests.get(requestKey);
+                }
+
+                const requestPromise = fetchAccountData(searchTerm).finally(() => {
+                    if (requestKey) {
+                        pendingRequests.delete(requestKey);
+                    }
+                });
+
+                if (requestKey) {
+                    pendingRequests.set(requestKey, requestPromise);
+                }
+
+                return requestPromise;
+            }
+
+            function clearTimer(map, element) {
+                if (!map.has(element)) {
+                    return;
+                }
+
+                const timerId = map.get(element);
+                clearTimeout(timerId);
+                map.delete(element);
+            }
+
+            function scheduleShow(element) {
+                clearTimer(hideTimers, element);
+
+                if (showTimers.has(element)) {
+                    return;
+                }
+
+                const timerId = setTimeout(() => {
+                    showTimers.delete(element);
+                    ensurePopover(element).then(popover => {
+                        if (popover) {
+                            popover.show();
+                        }
+                    });
+                }, 150);
+
+                showTimers.set(element, timerId);
+            }
+
+            function scheduleHide(element) {
+                clearTimer(showTimers, element);
+
+                const timerId = setTimeout(() => {
+                    hideTimers.delete(element);
+                    const popover = popoverInstances.get(element);
+                    if (popover) {
+                        popover.hide();
+                    }
+                }, 200);
+
+                hideTimers.set(element, timerId);
+            }
+
+            function ensurePopover(element) {
+                if (typeof window.generatePlayerCardHTML !== 'function') {
+                    return Promise.resolve(null);
+                }
+
+                return requestAccount(element).then(account => {
+                    if (!account) {
+                        return null;
+                    }
+
+                    const popover = getOrCreatePopover(element, account);
+                    return popover;
+                });
+            }
+
+            function getOrCreatePopover(element, account) {
+                let popover = popoverInstances.get(element);
+                const username = normalize(account.username ?? '');
+                const accountId = normalize(account.crand ?? account.accountId ?? account.account_id ?? '');
+                const usernameAttr = username.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                const accountIdAttr = accountId.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+                if (username) {
+                    element.dataset.username = usernameAttr;
+                }
+
+                if (accountId) {
+                    element.dataset.accountId = accountIdAttr;
+                }
+
+                const content = window.generatePlayerCardHTML(account);
+
+                if (!content) {
+                    return null;
+                }
+
+                if (!popover) {
+                    popover = new bootstrap.Popover(element, {
+                        trigger: 'manual',
+                        html: true,
+                        sanitize: false,
+                        customClass: 'player-card-popover',
+                        content: content
+                    });
+
+                    popoverInstances.set(element, popover);
+
+                    element.addEventListener('shown.bs.popover', () => handlePopoverShown(element));
+                    element.addEventListener('hide.bs.popover', () => {
+                        clearTimer(showTimers, element);
+                        clearTimer(hideTimers, element);
+                    });
+                } else if (typeof popover.setContent === 'function') {
+                    popover.setContent({ '.popover-body': content });
+                } else {
+                    popover._config = popover._config || {};
+                    popover._config.content = content;
+                    const tip = popover.getTipElement ? popover.getTipElement() : null;
+                    if (tip) {
+                        const body = tip.querySelector('.popover-body');
+                        if (body) {
+                            body.innerHTML = content;
+                        }
+                    }
+                }
+
+                return popover;
+            }
+
+            function handlePopoverShown(element) {
+                const popover = popoverInstances.get(element);
+                if (!popover || typeof popover.getTipElement !== 'function') {
+                    return;
+                }
+
+                const tipElement = popover.getTipElement();
+                if (!tipElement) {
+                    return;
+                }
+
+                if (!tipElement.dataset.playerCardPopoverBound) {
+                    const clearHide = () => clearTimer(hideTimers, element);
+                    const delayedHide = () => scheduleHide(element);
+
+                    tipElement.addEventListener('mouseenter', clearHide);
+                    tipElement.addEventListener('mouseleave', delayedHide);
+                    tipElement.dataset.playerCardPopoverBound = 'true';
+                }
+
+                if (window.bootstrap && bootstrap.Tooltip) {
+                    const tooltipElements = tipElement.querySelectorAll('[data-bs-toggle="tooltip"]');
+                    tooltipElements.forEach(el => {
+                        const instance = bootstrap.Tooltip.getInstance(el);
+                        if (instance && typeof instance.update === 'function') {
+                            instance.update();
+                        } else if (typeof bootstrap.Tooltip.getOrCreateInstance === 'function') {
+                            bootstrap.Tooltip.getOrCreateInstance(el);
+                        } else {
+                            new bootstrap.Tooltip(el);
+                        }
+                    });
+                }
+
+                if (window.bootstrap && bootstrap.Popover) {
+                    const popoverElements = tipElement.querySelectorAll('[data-bs-toggle="popover"]');
+                    popoverElements.forEach(el => {
+                        const instance = bootstrap.Popover.getInstance(el);
+                        if (instance && typeof instance.update === 'function') {
+                            instance.update();
+                        } else if (typeof bootstrap.Popover.getOrCreateInstance === 'function') {
+                            bootstrap.Popover.getOrCreateInstance(el);
+                        } else {
+                            new bootstrap.Popover(el);
+                        }
+                    });
+                }
+            }
+
+            function bindElement(element) {
+                if (!(element instanceof HTMLElement)) {
+                    return;
+                }
+
+                if (element.dataset[BOUND_FLAG]) {
+                    return;
+                }
+
+                element.dataset[BOUND_FLAG] = 'true';
+
+                const showHandler = () => scheduleShow(element);
+                const hideHandler = () => scheduleHide(element);
+
+                if (supportsHover) {
+                    element.addEventListener('mouseenter', showHandler);
+                    element.addEventListener('mouseleave', hideHandler);
+                }
+
+                element.addEventListener('focus', showHandler);
+                element.addEventListener('blur', hideHandler);
+            }
+
+            function bindAll(root) {
+                const elements = (root instanceof Element ? root : document).querySelectorAll(USERNAME_SELECTOR);
+                elements.forEach(bindElement);
+            }
+
+            function observeUsernameElements() {
+                if (!('MutationObserver' in window) || !document.body) {
+                    return;
+                }
+
+                const observer = new MutationObserver(mutations => {
+                    mutations.forEach(mutation => {
+                        mutation.addedNodes.forEach(node => {
+                            if (!(node instanceof Element)) {
+                                return;
+                            }
+
+                            if (node.matches(USERNAME_SELECTOR)) {
+                                bindElement(node);
+                            }
+
+                            bindAll(node);
+                        });
+                    });
+                });
+
+                observer.observe(document.body, {
+                    childList: true,
+                    subtree: true
+                });
+            }
+
+            function initialize() {
+                if (!document.body) {
+                    return;
+                }
+
+                bindAll(document);
+                observeUsernameElements();
+            }
+
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', initialize);
+            } else {
+                initialize();
+            }
+        })();
+
 
         
         function LoadContainerLoot(containerLootId, callback = null) {

--- a/html/php-components/feed-card.php
+++ b/html/php-components/feed-card.php
@@ -22,6 +22,10 @@ $feedCardHasRewards = false;
 $feedCardTitle = "";
 $feedCardHostName = null;
 $feedCardHostName2 = null;
+$feedCardHostNameRaw = null;
+$feedCardHostName2Raw = null;
+$feedCardHostId = null;
+$feedCardHostId2 = null;
 $feedCardDate = new DateTime();
 $feedCardHasCreatedBy = true;
 $feedCardExpired = false;
@@ -39,10 +43,25 @@ if (isset($feedCard["text"]))
     $feedCardDesc = htmlspecialchars($feedCard["text"]);
 
 if (isset($feedCard["account_1_username"]))
-    $feedCardHostName = htmlspecialchars($feedCard["account_1_username"]);
+{
+    $feedCardHostNameRaw = $feedCard["account_1_username"];
+    $feedCardHostName = htmlspecialchars($feedCardHostNameRaw);
+}
+
+if (isset($feedCard["account_1_id"]))
+    $feedCardHostId = htmlspecialchars((string)$feedCard["account_1_id"], ENT_QUOTES, 'UTF-8');
 
 if (isset($feedCard["account_2_username"]))
-    $feedCardHostName2 = htmlspecialchars($feedCard['account_2_username']);
+{
+    $feedCardHostName2Raw = $feedCard['account_2_username'];
+    $feedCardHostName2 = htmlspecialchars($feedCardHostName2Raw);
+}
+
+if (isset($feedCard["account_2_id"]))
+    $feedCardHostId2 = htmlspecialchars((string)$feedCard["account_2_id"], ENT_QUOTES, 'UTF-8');
+
+$feedCardHostNameAttr = $feedCardHostNameRaw !== null ? htmlspecialchars($feedCardHostNameRaw, ENT_QUOTES, 'UTF-8') : '';
+$feedCardHostName2Attr = $feedCardHostName2Raw !== null ? htmlspecialchars($feedCardHostName2Raw, ENT_QUOTES, 'UTF-8') : '';
 
 if (isset($feedCard["event_date"]))
 {
@@ -284,8 +303,8 @@ $feedCardDateDetailed = date_format($feedCardDate,"M j, Y H:i:s");
                 </a>
                 <?php if ($feedCardHasCreatedBy) { ?>
                 <p class="card-text">
-                    <small class="text-body-secondary"><?php if (!$feedCardCreatedByShowOnlyDate) { ?><?php echo $feedCardCreatedByPrefix; ?> by <a href="<?php echo Version::urlBetaPrefix(); ?>/u/<?php echo urlencode($feedCardHostName); ?>" class="username"><?php echo $feedCardHostName; ?></a>
-                    <?php if ($feedCardHostName2 != null) { ?> and <a href="<?php echo Version::urlBetaPrefix(); ?>/u/<?php echo urlencode($feedCardHostName2); ?>" class="username"><?php echo $feedCardHostName2;?></a><?php } ?>
+                    <small class="text-body-secondary"><?php if (!$feedCardCreatedByShowOnlyDate) { ?><?php echo $feedCardCreatedByPrefix; ?> by <a href="<?php echo Version::urlBetaPrefix(); ?>/u/<?php echo urlencode($feedCardHostName); ?>" class="username" data-account-id="<?php echo $feedCardHostId ?? ''; ?>" data-username="<?php echo $feedCardHostNameAttr; ?>"><?php echo $feedCardHostName; ?></a>
+                    <?php if ($feedCardHostName2 != null) { ?> and <a href="<?php echo Version::urlBetaPrefix(); ?>/u/<?php echo urlencode($feedCardHostName2); ?>" class="username" data-account-id="<?php echo $feedCardHostId2 ?? ''; ?>" data-username="<?php echo $feedCardHostName2Attr; ?>"><?php echo $feedCardHostName2;?></a><?php } ?>
                     <?php } if ($feedCardHasDate) { ?>on <span class="date" data-bs-toggle="tooltip" data-bs-placement="bottom"
                         data-bs-title="<?php echo $feedCardDateDetailed; ?> UTC"><?php echo $feedCardDateBasic; ?></span><?php } else { ?>until completed<?php } ?>
                     </small>

--- a/html/project-roadmaps.php
+++ b/html/project-roadmaps.php
@@ -702,8 +702,12 @@ $(document).ready(function() {
         <?php if (Kickback\Services\Session::isLoggedIn()) { ?>
         event.checklist.forEach(function(item) {
             let username = '';
-            if (item[1] != null)
-                username = `<a href="<?php echo Version::urlBetaPrefix(); ?>/u/${accounts[item[1]]}" class="username">${accounts[item[1]]}</a>`
+            if (item[1] != null) {
+                const accountIdAttr = String(item[1] ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                const usernameValue = accounts[item[1]] ?? '';
+                const usernameAttr = usernameValue.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                username = `<a href="<?php echo Version::urlBetaPrefix(); ?>/u/${accounts[item[1]]}" class="username" data-account-id="${accountIdAttr}" data-username="${usernameAttr}">${usernameValue}</a>`;
+            }
                 
             let icon = item[0] ? '<i class="fa-solid fa-square-check"></i>' : '<i class="fa-regular fa-square"></i>'; // Replace with your preferred icons
             checklistHtml += `<div class="checklist-item " ${item[0] ? "style='text-decoration: line-through;'" : ""} >${icon} ${username} ${item[2]}</div>`;

--- a/html/quest-giver-dashboard.php
+++ b/html/quest-giver-dashboard.php
@@ -1190,7 +1190,10 @@ $(document).ready(function () {
                     const item = $('<div class="list-group-item d-flex align-items-start"></div>');
                     const img = $('<img class="rounded me-3" style="width:40px;height:40px;">').attr('src', r.avatar);
                     const body = $('<div class="flex-grow-1"></div>');
-                    body.append(`<div><a href="/u/${r.username}" class="username" target="_blank">${r.username}</a></div>`);
+                    const accountId = r.accountId ?? r.account_id ?? r.crand ?? '';
+                    const accountIdAttr = String(accountId ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                    const usernameAttr = (r.username ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                    body.append(`<div><a href="/u/${r.username}" class="username" data-account-id="${accountIdAttr}" data-username="${usernameAttr}" target="_blank">${r.username}</a></div>`);
                     if (r.hostRating !== null) {
                         body.append('Host Rating: ' + renderStarRatingJs(r.hostRating) + '<br>');
                         body.append('Quest Rating: ' + renderStarRatingJs(r.questRating) + '<br>');

--- a/html/welcome-alpha-team.php
+++ b/html/welcome-alpha-team.php
@@ -67,7 +67,7 @@ $coleAccount = AccountController::getAccountById(new vRecordId('', 164))->data;
                                     "Hello hello, Alpha Team! It's an honor to have you here. Since the old days of liberating entire planets from our enemies, we've stood united with our allies against all odds! Now, join us to liberate&nbsp;Palworld&nbsp;next!"
                                 </p>
                                 <p class="mb-0">
-                                    — <a href="/u/Colethedragon" class="username">Colethedragon</a>
+                                    — <a href="/u/Colethedragon" class="username" data-account-id="" data-username="Colethedragon">Colethedragon</a>
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- add data attributes to account links and manual username anchors so they can be enriched with player-card popovers
- implement a reusable username popover module that fetches, caches, and displays player cards with bootstrap popovers, including dynamic-node support
- adjust CSS to fit the player-card popover content and sanitize inline username rendering in various views

## Testing
- php -l html/Kickback/Backend/Views/vAccount.php
- php -l html/php-components/feed-card.php
- php -l html/php-components/base-page-javascript.php
- php -l html/game.php
- php -l html/project-roadmaps.php
- php -l html/quest-giver-dashboard.php
- php -l html/php-components/base-page-components.php
- php -l html/welcome-alpha-team.php
- php -l html/lich-landing.php

------
https://chatgpt.com/codex/tasks/task_b_68cf2fac48e48333bf0e8b3205946beb