### PR TITLE
Convert loot reveal into overlay with interaction hooks

### DIFF
--- a/html/assets/css/loot-opening.css
+++ b/html/assets/css/loot-opening.css
@@ -1,0 +1,324 @@
+/* Loot reveal experience styles */
+:root {
+    --loot-bg: radial-gradient(circle at 50% 0%, rgba(255, 250, 214, 0.35), rgba(26, 17, 45, 0.95));
+    --loot-card-bg: linear-gradient(160deg, rgba(36, 24, 68, 0.92), rgba(18, 12, 38, 0.95));
+    --loot-highlight: #ffd166;
+    --loot-rare: #00d1ff;
+    --loot-epic: #a855f7;
+    --loot-legendary: #f97316;
+    --loot-shadow: rgba(0, 0, 0, 0.55);
+}
+
+.loot-reveal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1.5rem;
+    z-index: 1050;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 240ms ease;
+    color: #fdf9ff;
+    visibility: hidden;
+}
+
+.loot-reveal.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+    visibility: visible;
+}
+
+.loot-reveal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 50% 10%, rgba(26, 17, 45, 0.92), rgba(5, 3, 12, 0.94));
+    backdrop-filter: blur(6px);
+    transition: opacity 240ms ease;
+    z-index: 0;
+    cursor: pointer;
+}
+
+.loot-reveal:not(.is-visible) .loot-reveal__backdrop {
+    opacity: 0;
+}
+
+.loot-reveal__panel {
+    position: relative;
+    min-height: 380px;
+    width: min(960px, 100%);
+    padding: 2rem 1rem 4.5rem;
+    border-radius: 24px;
+    background: var(--loot-bg);
+    overflow: hidden;
+    color: inherit;
+    box-shadow: 0 24px 64px rgba(15, 9, 24, 0.6);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 32px;
+    z-index: 1;
+}
+
+.loot-reveal__chest {
+    position: relative;
+    width: clamp(220px, 30vw, 320px);
+    height: clamp(150px, 20vw, 220px);
+    display: grid;
+    place-items: center;
+    perspective: 800px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+.loot-reveal__chest:disabled {
+    cursor: default;
+}
+
+.loot-reveal__chest:focus-visible {
+    outline: 3px solid rgba(255, 209, 102, 0.85);
+    outline-offset: 6px;
+    border-radius: 20px;
+}
+
+.loot-reveal__chest-body,
+.loot-reveal__chest-lid {
+    width: 100%;
+    height: 100%;
+    border-radius: 18px;
+    background: linear-gradient(145deg, #7b3f00, #4e2600);
+    box-shadow: inset 0 0 0 4px rgba(0, 0, 0, 0.35), 0 12px 40px rgba(0, 0, 0, 0.45);
+    position: absolute;
+    overflow: hidden;
+}
+
+.loot-reveal__chest-body::after,
+.loot-reveal__chest-lid::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(90deg, rgba(255, 255, 255, 0.18) 0%, transparent 40%, transparent 60%, rgba(255, 255, 255, 0.18) 100%);
+    mix-blend-mode: screen;
+    opacity: 0.6;
+}
+
+.loot-reveal__chest-body {
+    transform-origin: center;
+    transform: translateY(20%);
+}
+
+.loot-reveal__chest-lid {
+    height: 55%;
+    transform-origin: center bottom;
+    transform: translateY(-30%) rotateX(0deg);
+    transition: transform 620ms cubic-bezier(0.19, 1, 0.22, 1);
+    z-index: 2;
+}
+
+.loot-reveal.is-opening .loot-reveal__chest-lid {
+    transform: translateY(-110%) rotateX(-110deg);
+}
+
+.loot-reveal__sparkle {
+    position: absolute;
+    width: 140%;
+    height: 140%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -40%);
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.25), transparent 65%);
+    filter: blur(8px);
+    opacity: 0;
+    transition: opacity 480ms ease;
+}
+
+.loot-reveal.is-opening .loot-reveal__sparkle {
+    opacity: 1;
+}
+
+.loot-reveal__items {
+    position: relative;
+    width: min(960px, 100%);
+    flex: 1 1 auto;
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+}
+
+.loot-reveal__track-wrapper {
+    width: 100%;
+    overflow-x: auto;
+    padding: 1.25rem 0.25rem 0.5rem;
+    scrollbar-width: thin;
+}
+
+.loot-reveal__track {
+    display: inline-flex;
+    gap: 18px;
+    padding: 0 0.75rem;
+}
+
+.loot-reveal__item-card {
+    width: clamp(120px, 20vw, 168px);
+    min-height: 180px;
+    background: var(--loot-card-bg);
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    position: relative;
+    padding: 1rem 0.75rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 12px;
+    box-shadow: 0 18px 35px rgba(12, 8, 26, 0.6);
+    opacity: 0;
+    transform: translateY(40px) scale(0.9);
+    transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1), opacity 420ms ease;
+}
+
+.loot-reveal__item-card::before {
+    content: "";
+    position: absolute;
+    inset: -2px;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.22), transparent 55%);
+    opacity: 0;
+    transition: opacity 240ms ease;
+    pointer-events: none;
+}
+
+.loot-reveal__item-card.is-visible {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+.loot-reveal__item-card.is-updating::before {
+    opacity: 1;
+}
+
+.loot-reveal__item-card-image {
+    width: 96px;
+    aspect-ratio: 1;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    display: grid;
+    place-items: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.loot-reveal__item-card-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.4));
+}
+
+.loot-reveal__rarity-ring {
+    position: absolute;
+    inset: -4px;
+    border-radius: inherit;
+    border: 3px solid transparent;
+    pointer-events: none;
+}
+
+.loot-reveal__rarity-ring--rare {
+    border-color: var(--loot-rare);
+}
+
+.loot-reveal__rarity-ring--epic {
+    border-color: var(--loot-epic);
+}
+
+.loot-reveal__rarity-ring--legendary {
+    border-color: var(--loot-legendary);
+}
+
+.loot-reveal__item-name {
+    text-align: center;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.25;
+}
+
+.loot-reveal__item-count {
+    font-size: 1.35rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--loot-highlight);
+}
+
+.loot-reveal__item-count span {
+    display: inline-flex;
+    min-width: 2ch;
+    justify-content: flex-end;
+}
+
+.loot-reveal__item-count svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
+
+.loot-reveal__item-card.is-updating {
+    animation: loot-card-pop 320ms ease;
+}
+
+@keyframes loot-card-pop {
+    0% {
+        transform: translateY(0) scale(1);
+    }
+    45% {
+        transform: translateY(-6px) scale(1.06);
+        box-shadow: 0 24px 46px rgba(0, 0, 0, 0.55);
+    }
+    100% {
+        transform: translateY(0) scale(1);
+    }
+}
+
+.loot-reveal__status-text {
+    font-size: 0.9rem;
+    opacity: 0.78;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.loot-reveal__empty {
+    opacity: 0.6;
+    font-size: 1rem;
+}
+
+/* Accessibility: reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    .loot-reveal,
+    .loot-reveal * {
+        animation-duration: 1ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 1ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+/* Horizontal scrollbar styling for WebKit */
+.loot-reveal__track-wrapper::-webkit-scrollbar {
+    height: 8px;
+}
+
+.loot-reveal__track-wrapper::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.25);
+    border-radius: 999px;
+}
+
+.loot-reveal__track-wrapper::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+}

--- a/html/assets/js/lootOpening.js
+++ b/html/assets/js/lootOpening.js
@@ -1,0 +1,338 @@
+class LootReveal {
+    constructor(rootElement, options = {}) {
+        if (!rootElement) {
+            throw new Error('LootReveal requires a root element.');
+        }
+
+        this.root = rootElement;
+        this.config = Object.assign({
+            chestOpenDelay: 350,
+            itemRevealDelay: 420,
+            countAnimationDuration: 480,
+            chestOpenDuration: 900,
+            onChestOpen: null,
+            onChestClose: null
+        }, options);
+
+        this.state = 'idle';
+        this.normalizedRewards = [];
+
+        this.#build();
+    }
+
+    #build() {
+        this.root.classList.add('loot-reveal');
+        this.root.setAttribute('aria-hidden', 'true');
+        this.root.innerHTML = '';
+
+        const backdrop = document.createElement('div');
+        backdrop.className = 'loot-reveal__backdrop';
+
+        const panel = document.createElement('div');
+        panel.className = 'loot-reveal__panel';
+        panel.setAttribute('role', 'dialog');
+        panel.setAttribute('aria-modal', 'true');
+        panel.setAttribute('aria-label', 'Loot rewards');
+
+        const chest = document.createElement('button');
+        chest.type = 'button';
+        chest.className = 'loot-reveal__chest';
+        chest.setAttribute('aria-label', 'Open loot chest');
+        chest.setAttribute('aria-expanded', 'false');
+        chest.innerHTML = `
+            <div class="loot-reveal__chest-body"></div>
+            <div class="loot-reveal__chest-lid"></div>
+            <div class="loot-reveal__sparkle"></div>
+        `;
+
+        const items = document.createElement('div');
+        items.className = 'loot-reveal__items';
+        items.innerHTML = `
+            <div class="loot-reveal__track-wrapper">
+                <div class="loot-reveal__track"></div>
+            </div>
+        `;
+
+        const status = document.createElement('div');
+        status.className = 'loot-reveal__status-text';
+        status.textContent = 'Awaiting chest...';
+
+        panel.appendChild(chest);
+        panel.appendChild(items);
+        panel.appendChild(status);
+
+        this.root.appendChild(backdrop);
+        this.root.appendChild(panel);
+
+        this.backdropEl = backdrop;
+        this.panelEl = panel;
+        this.chestEl = chest;
+        this.trackEl = items.querySelector('.loot-reveal__track');
+        this.statusEl = status;
+        this.cardMap = new Map();
+
+        this.backdropEl.addEventListener('click', () => this.close('backdrop'));
+        this.chestEl.addEventListener('click', () => this.#handleChestClick());
+    }
+
+    open(rewards) {
+        if (!Array.isArray(rewards)) {
+            this.normalizedRewards = [];
+        } else {
+            this.normalizedRewards = rewards.map((reward) => this.#normalizeReward(reward));
+        }
+
+        this.#prepareForReveal();
+
+        this.state = 'ready';
+        this.statusEl.textContent = this.normalizedRewards.length > 0
+            ? 'Tap the chest to reveal your loot'
+            : 'Tap the chest to peek inside';
+
+        this.root.classList.add('is-visible');
+        this.root.setAttribute('aria-hidden', 'false');
+        if (typeof this.chestEl.focus === 'function') {
+            this.chestEl.focus({ preventScroll: true });
+        }
+    }
+
+    close(reason = 'manual') {
+        if (!this.root.classList.contains('is-visible')) {
+            return;
+        }
+
+        if (this.state === 'opening') {
+            return;
+        }
+
+        this.state = 'idle';
+        this.root.classList.remove('is-visible', 'is-opening');
+        this.root.setAttribute('aria-hidden', 'true');
+        this.statusEl.textContent = 'Awaiting chest...';
+        this.chestEl.setAttribute('aria-expanded', 'false');
+        this.#clearTrack();
+        this.normalizedRewards = [];
+
+        if (typeof this.config.onChestClose === 'function') {
+            this.config.onChestClose(reason);
+        }
+
+        this.root.dispatchEvent(new CustomEvent('lootreveal:close', {
+            detail: { reason }
+        }));
+    }
+
+    async #handleChestClick() {
+        if (this.state === 'ready') {
+            await this.#startReveal();
+            return;
+        }
+
+        if (this.state === 'finished') {
+            this.close('chest');
+        }
+    }
+
+    async #startReveal() {
+        if (this.state !== 'ready') {
+            return;
+        }
+
+        this.state = 'opening';
+        this.statusEl.textContent = 'Opening...';
+        this.root.classList.remove('is-opening');
+        this.#clearTrack();
+        this.chestEl.disabled = true;
+
+        if (typeof this.config.onChestOpen === 'function') {
+            this.config.onChestOpen(this.normalizedRewards.slice());
+        }
+
+        this.root.dispatchEvent(new CustomEvent('lootreveal:chestopen', {
+            detail: {
+                rewards: this.normalizedRewards.slice()
+            }
+        }));
+
+        await this.#delay(this.config.chestOpenDelay);
+        this.root.classList.add('is-opening');
+        await this.#delay(this.config.chestOpenDuration);
+
+        if (this.normalizedRewards.length === 0) {
+            this.#renderEmpty();
+        } else {
+            for (const reward of this.normalizedRewards) {
+                await this.#revealReward(reward);
+                await this.#delay(this.config.itemRevealDelay);
+            }
+        }
+
+        this.state = 'finished';
+        this.statusEl.textContent = 'Tap the chest to close';
+        this.chestEl.disabled = false;
+        this.chestEl.setAttribute('aria-expanded', 'true');
+    }
+
+    #prepareForReveal() {
+        this.root.classList.remove('is-opening');
+        this.chestEl.disabled = false;
+        this.chestEl.setAttribute('aria-expanded', 'false');
+        this.#clearTrack();
+    }
+
+    #clearTrack() {
+        this.trackEl.innerHTML = '';
+        this.cardMap.clear();
+        const scroller = this.trackEl.parentElement;
+        if (scroller) {
+            if (typeof scroller.scrollTo === 'function') {
+                scroller.scrollTo({ left: 0, behavior: 'auto' });
+            } else {
+                scroller.scrollLeft = 0;
+            }
+        }
+    }
+
+    #renderEmpty() {
+        this.#clearTrack();
+        const empty = document.createElement('div');
+        empty.className = 'loot-reveal__empty';
+        empty.textContent = 'Chest was empty... maybe next time!';
+        this.trackEl.appendChild(empty);
+    }
+
+    async #revealReward(reward) {
+        const normalized = this.#normalizeReward(reward);
+        const existing = this.cardMap.get(normalized.itemId);
+
+        if (existing) {
+            const next = existing.count + normalized.amount;
+            this.#animateCount(existing.countElement, existing.count, next);
+            existing.count = next;
+            existing.card.classList.remove('is-updating');
+            void existing.card.offsetWidth;
+            existing.card.classList.add('is-updating');
+            return;
+        }
+
+        const card = this.#createCard(normalized);
+        this.cardMap.set(normalized.itemId, {
+            card,
+            count: normalized.amount,
+            countElement: card.querySelector('[data-count]')
+        });
+        this.trackEl.appendChild(card);
+
+        requestAnimationFrame(() => {
+            card.classList.add('is-visible');
+        });
+    }
+
+    #createCard(reward) {
+        const card = document.createElement('div');
+        card.className = 'loot-reveal__item-card';
+
+        const imageWrapper = document.createElement('div');
+        imageWrapper.className = 'loot-reveal__item-card-image';
+
+        if (reward.image) {
+            const img = document.createElement('img');
+            img.src = reward.image;
+            img.alt = reward.name;
+            imageWrapper.appendChild(img);
+        } else {
+            const placeholder = document.createElement('div');
+            placeholder.textContent = reward.name.charAt(0).toUpperCase();
+            placeholder.style.fontSize = '2.8rem';
+            placeholder.style.fontWeight = '700';
+            placeholder.style.color = 'rgba(255, 255, 255, 0.7)';
+            imageWrapper.appendChild(placeholder);
+        }
+
+        if (reward.rarity) {
+            const ring = document.createElement('div');
+            ring.className = 'loot-reveal__rarity-ring';
+            const rarityClass = {
+                common: '',
+                rare: 'loot-reveal__rarity-ring--rare',
+                epic: 'loot-reveal__rarity-ring--epic',
+                legendary: 'loot-reveal__rarity-ring--legendary'
+            }[reward.rarity];
+
+            if (rarityClass) {
+                ring.classList.add(rarityClass);
+            }
+
+            imageWrapper.appendChild(ring);
+        }
+
+        const name = document.createElement('div');
+        name.className = 'loot-reveal__item-name';
+        name.textContent = reward.name;
+
+        const count = document.createElement('div');
+        count.className = 'loot-reveal__item-count';
+        count.innerHTML = `
+            <span data-count>${reward.amount}</span>
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M4.5 6.75a2.25 2.25 0 0 1 2.25-2.25h10.5A2.25 2.25 0 0 1 19.5 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 17.25V6.75zm2.25-.75a.75.75 0 0 0-.75.75v10.5c0 .414.336.75.75.75h10.5a.75.75 0 0 0 .75-.75V6.75a.75.75 0 0 0-.75-.75H6.75zm5.25 2.25a.75.75 0 0 1 .75.75v2.25H15a.75.75 0 0 1 0 1.5h-2.25V15a.75.75 0 0 1-1.5 0v-2.25H9a.75.75 0 0 1 0-1.5h2.25V9a.75.75 0 0 1 .75-.75z"></path>
+            </svg>
+        `;
+
+        card.appendChild(imageWrapper);
+        card.appendChild(name);
+        card.appendChild(count);
+
+        card.addEventListener('animationend', (event) => {
+            if (event.animationName === 'loot-card-pop') {
+                card.classList.remove('is-updating');
+            }
+        });
+
+        return card;
+    }
+
+    #normalizeReward(reward) {
+        if (!reward || typeof reward !== 'object') {
+            throw new Error('Each reward should be an object describing the loot item.');
+        }
+
+        const itemId = reward.itemId ?? reward.id;
+        if (itemId === undefined) {
+            throw new Error('Reward is missing an itemId (or id) property.');
+        }
+
+        return {
+            itemId,
+            name: reward.name ?? 'Unknown Loot',
+            amount: Number(reward.amount ?? reward.quantity ?? 1),
+            rarity: reward.rarity ?? 'common',
+            image: reward.image ?? null
+        };
+    }
+
+    #animateCount(node, from, to) {
+        const duration = this.config.countAnimationDuration;
+        const start = performance.now();
+
+        const step = (now) => {
+            const elapsed = Math.min((now - start) / duration, 1);
+            const value = Math.floor(from + (to - from) * elapsed);
+            node.textContent = value.toString();
+
+            if (elapsed < 1) {
+                requestAnimationFrame(step);
+            } else {
+                node.textContent = to.toString();
+            }
+        };
+
+        requestAnimationFrame(step);
+    }
+
+    #delay(ms) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+}
+
+window.LootReveal = LootReveal;

--- a/html/loot-reveal-demo.php
+++ b/html/loot-reveal-demo.php
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Loot Reveal Demo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/kickback-kingdom.css">
+    <link rel="stylesheet" href="assets/css/loot-opening.css">
+    <style>
+        body {
+            background: radial-gradient(circle at top, #1a102b, #05020b 70%);
+            min-height: 100vh;
+            margin: 0;
+            color: #fff;
+            font-family: 'Nunito', sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 32px;
+            padding: 4rem 1rem 6rem;
+        }
+
+        h1 {
+            margin: 0;
+            font-weight: 800;
+            letter-spacing: 0.04em;
+        }
+
+        .demo-controls {
+            display: flex;
+            gap: 16px;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+
+        .demo-controls button {
+            background: linear-gradient(135deg, #6d28d9, #3b82f6);
+            border: none;
+            color: #fff;
+            padding: 0.85rem 1.8rem;
+            border-radius: 999px;
+            font-weight: 700;
+            font-size: 1rem;
+            cursor: pointer;
+            box-shadow: 0 14px 30px rgba(59, 130, 246, 0.35);
+            transition: transform 220ms ease, box-shadow 220ms ease;
+        }
+
+        .demo-controls button:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 22px 40px rgba(109, 40, 217, 0.4);
+        }
+
+        .demo-controls button:active {
+            transform: translateY(0);
+        }
+
+        .demo-description {
+            max-width: 760px;
+            text-align: center;
+            line-height: 1.6;
+            opacity: 0.85;
+        }
+
+        .demo-event-log {
+            min-height: 1.5rem;
+            font-size: 0.95rem;
+            opacity: 0.7;
+        }
+    </style>
+</head>
+<body>
+    <h1>Loot Reveal Prototype</h1>
+    <p class="demo-description">
+        Click the buttons below to simulate different chest outcomes. A full-screen overlay will appear&mdash;tap the
+        chest to reveal its contents, then tap it again (or the backdrop) to close. Identical items combine into a
+        single card with a counting animation, while unique items animate out and line up in a horizontal, scrollable
+        spread.
+    </p>
+    <div class="demo-controls">
+        <button type="button" data-demo="mixed">Open Mixed Chest</button>
+        <button type="button" data-demo="duplicates">Open Duplicate Heavy Chest</button>
+        <button type="button" data-demo="legendary">Open Legendary Chest</button>
+    </div>
+    <div class="demo-event-log" id="demo-event-log" aria-live="polite"></div>
+    <div id="loot-root"></div>
+
+    <script src="assets/js/lootOpening.js"></script>
+    <script>
+        const demoData = {
+            mixed: [
+                { itemId: 101, name: 'Sapphire Sigil', rarity: 'rare', image: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=300&q=80' },
+                { itemId: 205, name: 'Arcane Dust', rarity: 'common', amount: 2 },
+                { itemId: 101, name: 'Sapphire Sigil', rarity: 'rare' },
+                { itemId: 305, name: 'Runebound Gauntlet', rarity: 'epic', image: 'https://images.unsplash.com/photo-1528821154947-1aa3d1b74963?auto=format&fit=crop&w=300&q=80' },
+                { itemId: 205, name: 'Arcane Dust', rarity: 'common' },
+                { itemId: 412, name: 'Luminous Feather', rarity: 'rare', image: 'https://images.unsplash.com/photo-1452587925148-ce544e77e70d?auto=format&fit=crop&w=300&q=80' }
+            ],
+            duplicates: [
+                { itemId: 501, name: 'Gold Coin', rarity: 'common', amount: 3 },
+                { itemId: 501, name: 'Gold Coin', rarity: 'common', amount: 2 },
+                { itemId: 501, name: 'Gold Coin', rarity: 'common' },
+                { itemId: 640, name: 'Guild Voucher', rarity: 'rare' },
+                { itemId: 501, name: 'Gold Coin', rarity: 'common', amount: 5 }
+            ],
+            legendary: [
+                { itemId: 9001, name: 'Phoenix Crown', rarity: 'legendary', image: 'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=300&q=80' },
+                { itemId: 813, name: 'Silver Bark Wand', rarity: 'epic', image: 'https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=300&q=80' },
+                { itemId: 205, name: 'Arcane Dust', rarity: 'common', amount: 4 },
+                { itemId: 305, name: 'Runebound Gauntlet', rarity: 'epic' }
+            ]
+        };
+
+        const root = document.getElementById('loot-root');
+        const log = document.getElementById('demo-event-log');
+
+        const writeLog = (message) => {
+            if (!log) {
+                return;
+            }
+
+            log.textContent = message;
+        };
+
+        writeLog('Awaiting chest interaction.');
+
+        const reveal = new LootReveal(root, {
+            onChestOpen: (payload) => {
+                const total = Array.isArray(payload) ? payload.length : 0;
+                console.log(`Chest open callback fired with ${total} reward${total === 1 ? '' : 's'}.`);
+            },
+            onChestClose: (reason) => {
+                console.log(`Chest close callback fired (${reason}).`);
+            }
+        });
+
+        reveal.root.addEventListener('lootreveal:chestopen', (event) => {
+            const rewards = event.detail?.rewards ?? [];
+            const total = Array.isArray(rewards) ? rewards.length : 0;
+            writeLog(`Chest opened with ${total} reward${total === 1 ? '' : 's'}.`);
+        });
+
+        reveal.root.addEventListener('lootreveal:close', (event) => {
+            const reason = event.detail?.reason ?? 'manual';
+            writeLog(`Loot overlay closed (${reason}).`);
+        });
+
+        const buttons = document.querySelectorAll('.demo-controls button');
+        buttons.forEach((button) => {
+            button.addEventListener('click', () => {
+                const type = button.dataset.demo;
+                reveal.open(demoData[type]);
+            });
+        });
+
+        reveal.open(demoData.mixed);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- turn the loot reveal widget into a full-screen overlay with backdrop, dialog panel, and focusable chest trigger
- add internal state management, custom events, and callback hooks when the chest is opened or the overlay is closed
- refresh the demo page to illustrate the overlay workflow and surface the new interaction triggers

## Testing
- php -l html/loot-reveal-demo.php

------
https://chatgpt.com/codex/tasks/task_b_68d0079b096c8333a945d74aee78b79c