### PR TITLE
Add confetti support to loot reveal demo

### DIFF
--- a/html/assets/js/confetti.js
+++ b/html/assets/js/confetti.js
@@ -1,0 +1,70 @@
+(function (global) {
+    'use strict';
+
+    const Confettiful = function (el) {
+        this.el = el;
+        this.containerEl = null;
+
+        this.confettiFrequency = 3;
+        this.confettiColors = ['#fce18a', '#ff726d', '#b48def', '#f4306d'];
+        this.confettiAnimations = ['slow', 'medium', 'fast'];
+
+        this._setupElements();
+        this._renderConfetti();
+    };
+
+    Confettiful.prototype._setupElements = function () {
+        const containerEl = document.createElement('div');
+        const elPosition = this.el.style.position;
+
+        if (elPosition !== 'relative' || elPosition !== 'absolute') {
+            this.el.style.position = 'relative';
+        }
+
+        containerEl.classList.add('confetti-container');
+        containerEl.style = 'pointer-events:none;z-index:10000;';
+        this.el.appendChild(containerEl);
+
+        this.containerEl = containerEl;
+    };
+
+    Confettiful.prototype._renderConfetti = function () {
+        this.confettiInterval = setInterval(() => {
+            const confettiEl = document.createElement('div');
+            const confettiSize = Math.floor(Math.random() * 3) + 7 + 'px';
+            const confettiBackground = this.confettiColors[Math.floor(Math.random() * this.confettiColors.length)];
+            const confettiLeft = Math.floor(Math.random() * this.el.offsetWidth) + 'px';
+            const confettiAnimation = this.confettiAnimations[Math.floor(Math.random() * this.confettiAnimations.length)];
+
+            confettiEl.classList.add('confetti', 'confetti--animation-' + confettiAnimation);
+            confettiEl.style.left = confettiLeft;
+            confettiEl.style.width = confettiSize;
+            confettiEl.style.height = confettiSize;
+            confettiEl.style.backgroundColor = confettiBackground;
+
+            confettiEl.removeTimeout = setTimeout(function () {
+                if (confettiEl.parentNode) {
+                    confettiEl.parentNode.removeChild(confettiEl);
+                }
+            }, 3000);
+
+            this.containerEl.appendChild(confettiEl);
+        }, 25);
+    };
+
+    function StartConfetti() {
+        global.confettiful = new Confettiful(document.querySelector('.js-container-confetti'));
+    }
+
+    function StopConfetti() {
+        delete global.confettiful;
+        if (global.jQuery) {
+            jQuery('#div1').remove();
+            jQuery('div').remove('.confetti-container');
+        }
+    }
+
+    global.Confettiful = Confettiful;
+    global.StartConfetti = StartConfetti;
+    global.StopConfetti = StopConfetti;
+})(window);

--- a/html/loot-reveal-demo.php
+++ b/html/loot-reveal-demo.php
@@ -40,6 +40,11 @@
             z-index: 0;
         }
 
+        body.loot-demo .loot-reveal__backdrop {
+            background: transparent;
+            backdrop-filter: none;
+        }
+
         h1 {
             margin: 0;
             font-weight: 800;
@@ -99,7 +104,7 @@
         }
     </style>
 </head>
-<body>
+<body class="loot-demo">
     <h1>Loot Reveal Prototype</h1>
     <p class="demo-description">
         Click the buttons below to simulate different chest outcomes. A full-screen overlay will appear&mdash;tap the
@@ -114,7 +119,12 @@
     </div>
     <div class="demo-event-log" id="demo-event-log" aria-live="polite"></div>
     <div id="loot-root"></div>
+    <div class="confetti-box" aria-hidden="true">
+        <div class="js-container-confetti" style="width: 100vw; height: 100vh;"></div>
+    </div>
 
+    <script src="assets/vendors/jquery/jquery-3.7.0.min.js"></script>
+    <script src="assets/js/confetti.js"></script>
     <script src="assets/js/lootOpening.js"></script>
     <script>
         const demoData = {
@@ -161,6 +171,9 @@
             },
             onChestClose: (reason) => {
                 console.log(`Chest close callback fired (${reason}).`);
+                if (typeof StopConfetti === 'function') {
+                    StopConfetti();
+                }
             }
         });
 
@@ -168,11 +181,20 @@
             const rewards = event.detail?.rewards ?? [];
             const total = Array.isArray(rewards) ? rewards.length : 0;
             writeLog(`Chest opened with ${total} reward${total === 1 ? '' : 's'}.`);
+            if (typeof StopConfetti === 'function') {
+                StopConfetti();
+            }
+            if (typeof StartConfetti === 'function') {
+                StartConfetti();
+            }
         });
 
         reveal.root.addEventListener('lootreveal:close', (event) => {
             const reason = event.detail?.reason ?? 'manual';
             writeLog(`Loot overlay closed (${reason}).`);
+            if (typeof StopConfetti === 'function') {
+                StopConfetti();
+            }
         });
 
         const buttons = document.querySelectorAll('.demo-controls button');

--- a/html/php-components/base-page-javascript.php
+++ b/html/php-components/base-page-javascript.php
@@ -14,6 +14,7 @@ use Kickback\Common\Version;
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.js"></script>
     <script src="<?= Version::urlBetaPrefix(); ?>/assets/vendors/qrcode/qrcode.min.js"></script>
     <script src="<?= Version::urlBetaPrefix(); ?>/assets/js/qrcode.js"></script>
+    <script src="<?= Version::urlBetaPrefix(); ?>/assets/js/confetti.js"></script>
 
     <!--<script src="assets/owl-carousel/owl.carousel.js"></script>-->
     <script>
@@ -1396,72 +1397,6 @@ use Kickback\Common\Version;
         {
             sessionStorage.setItem('showActionModal', 'false');
         }
-        
-        const Confettiful = function (el) {
-            this.el = el;
-            this.containerEl = null;
-
-            this.confettiFrequency = 3;
-            this.confettiColors = ['#fce18a', '#ff726d', '#b48def', '#f4306d'];
-            this.confettiAnimations = ['slow', 'medium', 'fast'];
-
-            this._setupElements();
-            this._renderConfetti();
-        };
-
-        Confettiful.prototype._setupElements = function () {
-        const containerEl = document.createElement('div');
-        const elPosition = this.el.style.position;
-
-        if (elPosition !== 'relative' || elPosition !== 'absolute') {
-            this.el.style.position = 'relative';
-        }
-
-        containerEl.classList.add('confetti-container');
-        containerEl.style="pointer-events:none;z-index:10000;";
-        this.el.appendChild(containerEl);
-
-        this.containerEl = containerEl;
-        };
-
-        Confettiful.prototype._renderConfetti = function () {
-        this.confettiInterval = setInterval(() => {
-            const confettiEl = document.createElement('div');
-            const confettiSize = Math.floor(Math.random() * 3) + 7 + 'px';
-            const confettiBackground = this.confettiColors[Math.floor(Math.random() * this.confettiColors.length)];
-            const confettiLeft = Math.floor(Math.random() * this.el.offsetWidth) + 'px';
-            const confettiAnimation = this.confettiAnimations[Math.floor(Math.random() * this.confettiAnimations.length)];
-
-            confettiEl.classList.add('confetti', 'confetti--animation-' + confettiAnimation);
-            confettiEl.style.left = confettiLeft;
-            confettiEl.style.width = confettiSize;
-            confettiEl.style.height = confettiSize;
-            confettiEl.style.backgroundColor = confettiBackground;
-
-            confettiEl.removeTimeout = setTimeout(function () {
-            confettiEl.parentNode.removeChild(confettiEl);
-            }, 3000);
-
-            this.containerEl.appendChild(confettiEl);
-        }, 25);
-        };
-
-
-
-        function StartConfetti()
-        {
-
-            window.confettiful = new Confettiful(document.querySelector('.js-container-confetti'));
-        }
-
-        function StopConfetti()
-        {
-            delete window.confettiful;
-            $("#div1").remove();
-            $("div").remove(".confetti-container");
-        }
-
-
         
         function enableBeta() {
             window.location.href = "/beta/";


### PR DESCRIPTION
## Summary
- extract the existing Confettiful implementation into a dedicated assets/js/confetti.js helper that exposes StartConfetti/StopConfetti for reuse
- wire the shared confetti script into the global base page bundle
- update the loot reveal demo to use the shared confetti helper, add the confetti container markup, and make the overlay backdrop transparent for embed scenarios

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d016933a948333b422847950ebb91c