### PR TITLE
Center loot reveal overlay and adjust demo confetti

### DIFF
--- a/html/assets/css/loot-opening.css
+++ b/html/assets/css/loot-opening.css
@@ -12,9 +12,8 @@
 .loot-reveal {
     position: fixed;
     inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: grid;
+    place-items: center;
     padding: 3rem 1.5rem;
     z-index: 1050;
     opacity: 0;
@@ -22,6 +21,7 @@
     transition: opacity 240ms ease;
     color: #fdf9ff;
     visibility: hidden;
+    min-height: 100vh;
 }
 
 .loot-reveal.is-visible {

--- a/html/loot-reveal-demo.php
+++ b/html/loot-reveal-demo.php
@@ -41,8 +41,8 @@
         }
 
         body.loot-demo .loot-reveal__backdrop {
-            background: transparent;
-            backdrop-filter: none;
+            background: rgba(5, 3, 12, 0.55);
+            backdrop-filter: blur(4px);
         }
 
         h1 {
@@ -164,6 +164,16 @@
 
         writeLog('Awaiting chest interaction.');
 
+        const startClosedChestConfetti = () => {
+            if (typeof StopConfetti === 'function') {
+                StopConfetti();
+            }
+
+            if (typeof StartConfetti === 'function') {
+                StartConfetti();
+            }
+        };
+
         const reveal = new LootReveal(root, {
             onChestOpen: (payload) => {
                 const total = Array.isArray(payload) ? payload.length : 0;
@@ -181,12 +191,6 @@
             const rewards = event.detail?.rewards ?? [];
             const total = Array.isArray(rewards) ? rewards.length : 0;
             writeLog(`Chest opened with ${total} reward${total === 1 ? '' : 's'}.`);
-            if (typeof StopConfetti === 'function') {
-                StopConfetti();
-            }
-            if (typeof StartConfetti === 'function') {
-                StartConfetti();
-            }
         });
 
         reveal.root.addEventListener('lootreveal:close', (event) => {
@@ -202,10 +206,12 @@
             button.addEventListener('click', () => {
                 const type = button.dataset.demo;
                 reveal.open(demoData[type]);
+                startClosedChestConfetti();
             });
         });
 
         reveal.open(demoData.mixed);
+        startClosedChestConfetti();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- center the loot reveal overlay within the viewport by switching to a grid layout
- dim the demo backdrop slightly to keep focus on the chest during the reveal
- trigger confetti as soon as the closed chest is displayed in the demo rather than waiting for the open event

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d0196a1ac483338138480d56ac41c8