### PR TITLE
Ensure loot reveal overlay requires opening chest

### DIFF
--- a/html/assets/js/lootOpening.js
+++ b/html/assets/js/lootOpening.js
@@ -103,7 +103,8 @@ class LootReveal {
             }
         });
 
-        this.backdropEl.addEventListener('click', () => this.close('backdrop'));
+        this.backdropEl.addEventListener('click', (event) => this.#handleBackdropInteraction(event));
+        this.panelEl.addEventListener('click', (event) => this.#handlePanelInteraction(event));
         this.chestEl.addEventListener('click', () => this.#handleChestClick());
     }
 
@@ -158,6 +159,33 @@ class LootReveal {
         this.root.dispatchEvent(new CustomEvent('lootreveal:close', {
             detail: { reason }
         }));
+    }
+
+    #handleBackdropInteraction(event) {
+        if (this.state === 'ready') {
+            event.preventDefault();
+            event.stopPropagation();
+            void this.#startReveal();
+            return;
+        }
+
+        if (this.state === 'finished') {
+            this.close('backdrop');
+        }
+    }
+
+    #handlePanelInteraction(event) {
+        if (this.state !== 'ready') {
+            return;
+        }
+
+        if (!this.panelEl.contains(event.target)) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        void this.#startReveal();
     }
 
     async #handleChestClick() {


### PR DESCRIPTION
## Summary
- trigger chest opening when the loot overlay is clicked anywhere, including the backdrop
- block closing the overlay from the backdrop until the chest has been opened

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d01bb6c7788333a179abff6ff265c1