### PR TITLE
Refactor loot reveal to use Bootstrap modal

### DIFF
--- a/html/assets/css/loot-opening.css
+++ b/html/assets/css/loot-opening.css
@@ -10,38 +10,23 @@
 }
 
 .loot-reveal {
-    position: fixed;
-    inset: 0;
-    display: grid;
-    place-items: center;
-    padding: 3rem 1.5rem;
-    z-index: 1050;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 240ms ease;
+    width: 100%;
     color: #fdf9ff;
-    visibility: hidden;
-    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 2.5rem 1.25rem 4.75rem;
 }
 
-.loot-reveal.is-visible {
-    opacity: 1;
-    pointer-events: auto;
-    visibility: visible;
-}
-
-.loot-reveal__backdrop {
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(circle at 50% 10%, rgba(26, 17, 45, 0.92), rgba(5, 3, 12, 0.94));
+.modal-backdrop {
     backdrop-filter: blur(6px);
-    transition: opacity 240ms ease;
-    z-index: 0;
-    cursor: pointer;
+    opacity: 0;
 }
 
-.loot-reveal:not(.is-visible) .loot-reveal__backdrop {
-    opacity: 0;
+.modal-backdrop.show {
+    opacity: 1;
+    background: radial-gradient(circle at 50% 10%, rgba(26, 17, 45, 0.92), rgba(5, 3, 12, 0.94));
 }
 
 .loot-reveal__panel {

--- a/html/loot-reveal-demo.php
+++ b/html/loot-reveal-demo.php
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/vendors/bootstrap/bootstrap.min.css">
     <link rel="stylesheet" href="assets/css/kickback-kingdom.css">
     <link rel="stylesheet" href="assets/css/loot-opening.css">
     <style>
@@ -38,11 +39,6 @@
             opacity: 0.35;
             mix-blend-mode: screen;
             z-index: 0;
-        }
-
-        body.loot-demo .loot-reveal__backdrop {
-            background: rgba(5, 3, 12, 0.55);
-            backdrop-filter: blur(4px);
         }
 
         h1 {
@@ -117,12 +113,23 @@
         <button type="button" data-demo="legendary">Open Legendary Chest</button>
     </div>
     <div class="demo-event-log" id="demo-event-log" aria-live="polite"></div>
-    <div id="loot-root"></div>
+    <div id="loot-root">
+        <div class="modal fade loot-reveal-modal" id="loot-reveal-modal" tabindex="-1" aria-hidden="true" aria-modal="true" aria-label="Loot rewards" data-loot-modal>
+            <div class="modal-dialog modal-dialog-centered modal-xl loot-reveal__dialog">
+                <div class="modal-content bg-transparent border-0">
+                    <div class="modal-body p-0">
+                        <div class="loot-reveal" data-loot-container></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class="confetti-box" aria-hidden="true">
         <div class="js-container-confetti" style="width: 100vw; height: 100vh;"></div>
     </div>
 
     <script src="assets/vendors/jquery/jquery-3.7.0.min.js"></script>
+    <script src="assets/vendors/bootstrap/bootstrap.bundle.min.js"></script>
     <script src="assets/js/confetti.js"></script>
     <script src="assets/js/lootOpening.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- add Bootstrap assets and modal markup to the demo shell so the loot reveal mounts inside a Bootstrap modal
- rebuild the loot reveal component to render into the modal container, use bootstrap.Modal for lifecycle, and adjust backdrop handling
- update styling so the reveal fits within the modal body and restyle the Bootstrap backdrop with the previous gradient/blur treatment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d01d82e5e883339a69915e2ff128cc