### PR TITLE
Animate loot cards emerging from chest

### DIFF
--- a/html/assets/css/loot-opening.css
+++ b/html/assets/css/loot-opening.css
@@ -240,6 +240,7 @@
 .loot-reveal__track-wrapper {
     width: 100%;
     overflow-x: auto;
+    overflow-y: visible;
     padding: 1.25rem 0.25rem 0.5rem;
     scrollbar-width: thin;
 }
@@ -255,6 +256,9 @@
     --loot-item-offset-y: 0px;
     --loot-item-scale: 1;
     --loot-item-rotation: 0deg;
+    --loot-item-arc: 120px;
+    --loot-item-flight-duration: 640ms;
+    --loot-item-flight-delay: 0ms;
     width: clamp(120px, 20vw, 168px);
     min-height: 180px;
     background: var(--loot-card-bg);
@@ -270,7 +274,7 @@
     box-shadow: 0 18px 35px rgba(12, 8, 26, 0.6);
     opacity: 0;
     transform: translate3d(var(--loot-item-offset-x), var(--loot-item-offset-y), 0) scale(var(--loot-item-scale)) rotate(var(--loot-item-rotation));
-    transition: transform 520ms cubic-bezier(0.22, 1, 0.36, 1), opacity 360ms ease;
+    transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1), opacity 320ms ease;
     will-change: transform, opacity;
 }
 
@@ -287,6 +291,7 @@
 
 .loot-reveal__item-card.is-visible {
     opacity: 1;
+    animation: loot-card-flight var(--loot-item-flight-duration) cubic-bezier(0.22, 1, 0.36, 1) var(--loot-item-flight-delay) forwards;
 }
 
 .loot-reveal__item-card.is-updating::before {
@@ -362,6 +367,21 @@
 
 .loot-reveal__item-card.is-updating {
     animation: loot-card-pop 320ms ease;
+}
+
+@keyframes loot-card-flight {
+    0% {
+        opacity: 0;
+        transform: translate3d(var(--loot-item-offset-x), var(--loot-item-offset-y), 0) scale(var(--loot-item-scale)) rotate(var(--loot-item-rotation));
+    }
+    55% {
+        opacity: 1;
+        transform: translate3d(calc(var(--loot-item-offset-x) * 0.4), calc(var(--loot-item-offset-y) * 0.5 - var(--loot-item-arc)), 0) scale(1.08) rotate(0deg);
+    }
+    100% {
+        opacity: 1;
+        transform: translate3d(0, 0, 0) scale(1) rotate(0deg);
+    }
 }
 
 @keyframes loot-card-pop {

--- a/html/assets/js/lootOpening.js
+++ b/html/assets/js/lootOpening.js
@@ -536,35 +536,41 @@ class LootReveal {
         const offsetX = chestX - cardX;
         const offsetY = chestY - cardY;
         const rotation = (Math.random() * 16 - 8).toFixed(2);
+        const travelDistance = Math.hypot(offsetX, offsetY);
+        const clampedDistance = Math.min(Math.max(travelDistance, 160), 720);
+        const duration = Math.round(520 + clampedDistance * 0.25);
+        const delay = Math.round(Math.random() * 90);
+        const arcHeight = Math.round(Math.min(Math.max(travelDistance * 0.35, 80), 200));
 
+        card.classList.remove('is-visible');
         card.style.setProperty('--loot-item-offset-x', `${offsetX}px`);
         card.style.setProperty('--loot-item-offset-y', `${offsetY}px`);
         card.style.setProperty('--loot-item-scale', '0.45');
         card.style.setProperty('--loot-item-rotation', `${rotation}deg`);
+        card.style.setProperty('--loot-item-flight-duration', `${duration}ms`);
+        card.style.setProperty('--loot-item-flight-delay', `${delay}ms`);
+        card.style.setProperty('--loot-item-arc', `${arcHeight}px`);
 
         requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-                card.classList.add('is-visible');
-                card.style.setProperty('--loot-item-offset-x', '0px');
-                card.style.setProperty('--loot-item-offset-y', '0px');
-                card.style.setProperty('--loot-item-scale', '1');
-                card.style.setProperty('--loot-item-rotation', '0deg');
-            });
+            card.classList.add('is-visible');
         });
 
         const cleanup = (event) => {
-            if (event.target !== card || event.propertyName !== 'transform') {
+            if (event.target !== card || event.animationName !== 'loot-card-flight') {
                 return;
             }
 
-            card.removeEventListener('transitionend', cleanup);
+            card.removeEventListener('animationend', cleanup);
             card.style.removeProperty('--loot-item-offset-x');
             card.style.removeProperty('--loot-item-offset-y');
             card.style.removeProperty('--loot-item-scale');
             card.style.removeProperty('--loot-item-rotation');
+            card.style.removeProperty('--loot-item-flight-duration');
+            card.style.removeProperty('--loot-item-flight-delay');
+            card.style.removeProperty('--loot-item-arc');
         };
 
-        card.addEventListener('transitionend', cleanup);
+        card.addEventListener('animationend', cleanup);
     }
 
     #normalizeReward(reward) {


### PR DESCRIPTION
## Summary
- animate newly revealed loot cards along an arcing path from the chest to their final slots
- tune loot card timing and allow the track wrapper to show the full flight path

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d093849e6883339d0a3d02f72605ee