### PR TITLE
Improve loot reveal item flight layering and motion

### DIFF
--- a/html/assets/css/loot-opening.css
+++ b/html/assets/css/loot-opening.css
@@ -235,6 +235,7 @@
     display: flex;
     align-items: stretch;
     justify-content: center;
+    z-index: 2;
 }
 
 .loot-reveal__track-wrapper {
@@ -276,6 +277,12 @@
     transform: translate3d(var(--loot-item-offset-x), var(--loot-item-offset-y), 0) scale(var(--loot-item-scale)) rotate(var(--loot-item-rotation));
     transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1), opacity 320ms ease;
     will-change: transform, opacity;
+}
+
+.loot-reveal__item-card.is-flying {
+    z-index: 5;
+    pointer-events: none;
+    filter: drop-shadow(0 24px 48px rgba(8, 4, 20, 0.55));
 }
 
 .loot-reveal__item-card::before {
@@ -374,9 +381,15 @@
         opacity: 0;
         transform: translate3d(var(--loot-item-offset-x), var(--loot-item-offset-y), 0) scale(var(--loot-item-scale)) rotate(var(--loot-item-rotation));
     }
-    55% {
+    45% {
         opacity: 1;
-        transform: translate3d(calc(var(--loot-item-offset-x) * 0.4), calc(var(--loot-item-offset-y) * 0.5 - var(--loot-item-arc)), 0) scale(1.08) rotate(0deg);
+        transform: translate3d(calc(var(--loot-item-offset-x) * 0.45), calc(var(--loot-item-offset-y) * 0.55 - var(--loot-item-arc)), 0) scale(1.08) rotate(0deg);
+    }
+    70% {
+        transform: translate3d(calc(var(--loot-item-offset-x) * 0.08), calc(var(--loot-item-offset-y) * 0.12 - var(--loot-item-arc) * 0.25), 0) scale(1.03) rotate(0deg);
+    }
+    85% {
+        transform: translate3d(0, -6px, 0) scale(1.015) rotate(0deg);
     }
     100% {
         opacity: 1;

--- a/html/assets/js/lootOpening.js
+++ b/html/assets/js/lootOpening.js
@@ -538,11 +538,12 @@ class LootReveal {
         const rotation = (Math.random() * 16 - 8).toFixed(2);
         const travelDistance = Math.hypot(offsetX, offsetY);
         const clampedDistance = Math.min(Math.max(travelDistance, 160), 720);
-        const duration = Math.round(520 + clampedDistance * 0.25);
-        const delay = Math.round(Math.random() * 90);
+        const duration = Math.round(620 + clampedDistance * 0.32);
+        const delay = Math.round(Math.random() * 110);
         const arcHeight = Math.round(Math.min(Math.max(travelDistance * 0.35, 80), 200));
 
         card.classList.remove('is-visible');
+        card.classList.add('is-flying');
         card.style.setProperty('--loot-item-offset-x', `${offsetX}px`);
         card.style.setProperty('--loot-item-offset-y', `${offsetY}px`);
         card.style.setProperty('--loot-item-scale', '0.45');
@@ -568,6 +569,7 @@ class LootReveal {
             card.style.removeProperty('--loot-item-flight-duration');
             card.style.removeProperty('--loot-item-flight-delay');
             card.style.removeProperty('--loot-item-arc');
+            card.classList.remove('is-flying');
         };
 
         card.addEventListener('animationend', cleanup);


### PR DESCRIPTION
## Summary
- ensure loot cards temporarily receive a high z-index while flying so they render above the UI
- smooth out the item launch animation with longer duration, subtle easing beats, and richer shadows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d0952e24cc8333b4712629544de605