### PR TITLE
Fix loot reveal card flashing

### DIFF
--- a/html/assets/css/loot-opening.css
+++ b/html/assets/css/loot-opening.css
@@ -277,19 +277,23 @@
     justify-content: flex-start;
     gap: 12px;
     box-shadow: 0 18px 35px rgba(12, 8, 26, 0.6);
-    opacity: 0;
-    transform: translate3d(0, 18px, 0) scale(0.95);
-    transition: opacity 260ms ease, transform 320ms cubic-bezier(0.16, 1, 0.3, 1);
-    will-change: transform, opacity;
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    transition: transform 320ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 320ms ease;
+    will-change: transform;
 }
 
 .loot-reveal__item-card.is-pending {
+    opacity: 0;
+    transform: translate3d(0, 18px, 0) scale(0.95);
     visibility: hidden;
+    pointer-events: none;
 }
 
 .loot-reveal__item-card.is-visible {
     opacity: 1;
     transform: translate3d(0, 0, 0) scale(1);
+    visibility: visible;
 }
 
 .loot-reveal__item-card--ghost {

--- a/html/assets/js/lootOpening.js
+++ b/html/assets/js/lootOpening.js
@@ -403,6 +403,7 @@ class LootReveal {
             onFinish: () => {
                 card.classList.remove('is-pending');
                 card.classList.add('is-visible');
+                this.#pulseCard(card, { delayFrame: true });
             }
         });
     }
@@ -418,18 +419,32 @@ class LootReveal {
         entry.count = next;
         entry.reward.amount = next;
 
-        card.classList.remove('is-updating');
-        void card.offsetWidth;
-        card.classList.add('is-updating');
-
         const targetRect = card.getBoundingClientRect();
 
         this.#playFlightAnimation(reward, targetRect, {
             onFinish: () => {
                 this.#animateCount(countElement, start, next);
-                card.classList.remove('is-updating');
+                this.#pulseCard(card);
             }
         });
+    }
+
+    #pulseCard(card, { delayFrame = false } = {}) {
+        if (!(card instanceof HTMLElement)) {
+            return;
+        }
+
+        const run = () => {
+            card.classList.remove('is-updating');
+            void card.offsetWidth;
+            card.classList.add('is-updating');
+        };
+
+        if (delayFrame) {
+            requestAnimationFrame(run);
+        } else {
+            run();
+        }
     }
 
     #playFlightAnimation(reward, targetRect, { onFinish } = {}) {


### PR DESCRIPTION
## Summary
- ensure loot grid cards keep their visible state instead of fading out when flights complete
- add a reusable helper to trigger the wobble animation for new and duplicate rewards

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d0a0f210948333b19401717d2ea683