### PR TITLE
Remove grid item card fade-in

### DIFF
--- a/html/assets/css/loot-opening.css
+++ b/html/assets/css/loot-opening.css
@@ -284,15 +284,11 @@
 }
 
 .loot-reveal__item-card.is-pending {
-    opacity: 0;
-    transform: translate3d(0, 18px, 0) scale(0.95);
     visibility: hidden;
     pointer-events: none;
 }
 
 .loot-reveal__item-card.is-visible {
-    opacity: 1;
-    transform: translate3d(0, 0, 0) scale(1);
     visibility: visible;
 }
 


### PR DESCRIPTION
## Summary
- stop applying opacity and transform adjustments to pending loot cards so they display without a redundant fade-in

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d0a3f516cc8333abae39967020b1b9