### PR TITLE
Remove fade-out from flying loot card animation

### DIFF
--- a/html/assets/js/lootOpening.js
+++ b/html/assets/js/lootOpening.js
@@ -481,7 +481,7 @@ class LootReveal {
             { transform: startTransform, opacity: 0 },
             { transform: startTransform, opacity: 1, offset: 0.18 },
             { transform: endTransform, opacity: 0.95, offset: 0.8 },
-            { transform: endTransform, opacity: 0 }
+            { transform: endTransform, opacity: 1 }
         ], {
             duration: 720,
             easing: 'cubic-bezier(0.22, 1, 0.36, 1)'


### PR DESCRIPTION
## Summary
- keep the flying reward card fully visible as it travels to its destination

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d0a695e1a083339375987b13871cd8