### PR TITLE
Simplify loot reveal item presentation

### DIFF
--- a/html/assets/css/loot-opening.css
+++ b/html/assets/css/loot-opening.css
@@ -264,23 +264,15 @@
 
 
 .loot-reveal__item-card {
-    width: clamp(120px, 20vw, 168px);
-    min-height: 180px;
-    background: var(--loot-card-bg);
-    border-radius: 18px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    width: clamp(110px, 18vw, 152px);
+    aspect-ratio: 1;
     position: relative;
-    padding: 1rem 0.75rem 1.25rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 12px;
-    box-shadow: 0 18px 35px rgba(12, 8, 26, 0.6);
+    display: block;
     opacity: 1;
     transform: translate3d(0, 0, 0) scale(1);
-    transition: transform 320ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 320ms ease;
+    transition: transform 320ms cubic-bezier(0.16, 1, 0.3, 1), filter 320ms ease;
     will-change: transform;
+    filter: drop-shadow(0 22px 48px rgba(8, 5, 18, 0.55));
 }
 
 .loot-reveal__item-card.is-pending {
@@ -300,89 +292,72 @@
     pointer-events: none;
     z-index: 1085;
     opacity: 0;
-    box-shadow: 0 26px 64px rgba(10, 6, 22, 0.55);
-}
-
-.loot-reveal__item-card::before {
-    content: "";
-    position: absolute;
-    inset: -2px;
-    border-radius: inherit;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.22), transparent 55%);
-    opacity: 0;
-    transition: opacity 240ms ease;
-    pointer-events: none;
-}
-
-.loot-reveal__item-card.is-updating::before {
-    opacity: 1;
+    filter: drop-shadow(0 22px 48px rgba(8, 5, 18, 0.55));
 }
 
 .loot-reveal__item-card-image {
-    width: 96px;
-    aspect-ratio: 1;
-    border-radius: 16px;
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.16);
-    display: grid;
-    place-items: center;
-    position: relative;
+    width: 100%;
+    height: 100%;
+    border-radius: 24px;
     overflow: hidden;
+    position: relative;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 .loot-reveal__item-card-image img {
     width: 100%;
     height: 100%;
+    display: block;
     object-fit: cover;
-    filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.4));
+    transform: scale(1.02);
 }
 
-.loot-reveal__rarity-ring {
-    position: absolute;
-    inset: -4px;
-    border-radius: inherit;
-    border: 3px solid transparent;
-    pointer-events: none;
+.loot-reveal__item-card-image--placeholder {
+    background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.25), transparent 58%),
+        linear-gradient(145deg, rgba(83, 54, 112, 0.75), rgba(40, 26, 71, 0.92));
 }
 
-.loot-reveal__rarity-ring--rare {
-    border-color: var(--loot-rare);
+.loot-reveal__item-card--rare .loot-reveal__item-card-image {
+    border-color: rgba(0, 209, 255, 0.35);
+    box-shadow: inset 0 0 0 2px rgba(0, 209, 255, 0.45);
 }
 
-.loot-reveal__rarity-ring--epic {
-    border-color: var(--loot-epic);
+.loot-reveal__item-card--epic .loot-reveal__item-card-image {
+    border-color: rgba(168, 85, 247, 0.45);
+    box-shadow: inset 0 0 0 2px rgba(168, 85, 247, 0.55);
 }
 
-.loot-reveal__rarity-ring--legendary {
-    border-color: var(--loot-legendary);
+.loot-reveal__item-card--legendary .loot-reveal__item-card-image {
+    border-color: rgba(249, 115, 22, 0.45);
+    box-shadow: inset 0 0 0 2px rgba(249, 115, 22, 0.55);
 }
 
-.loot-reveal__item-name {
-    text-align: center;
-    font-size: 1rem;
-    font-weight: 600;
-    line-height: 1.25;
+.loot-reveal__item-card--mythic .loot-reveal__item-card-image {
+    border-color: rgba(255, 255, 255, 0.45);
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.55);
 }
 
 .loot-reveal__item-count {
-    font-size: 1.35rem;
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
+    min-width: 42px;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(6, 4, 14, 0.82);
+    color: #fff;
     font-weight: 700;
+    font-size: 1.1rem;
+    line-height: 1;
     display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    color: var(--loot-highlight);
+    justify-content: center;
+    box-shadow: 0 12px 28px rgba(5, 3, 12, 0.45);
 }
 
 .loot-reveal__item-count span {
     display: inline-flex;
-    min-width: 2ch;
-    justify-content: flex-end;
-}
-
-.loot-reveal__item-count svg {
-    width: 18px;
-    height: 18px;
-    fill: currentColor;
+    justify-content: center;
 }
 
 .loot-reveal__item-card.is-updating {
@@ -395,7 +370,6 @@
     }
     45% {
         transform: translateY(-6px) scale(1.06);
-        box-shadow: 0 24px 46px rgba(0, 0, 0, 0.55);
     }
     100% {
         transform: translateY(0) scale(1);

--- a/html/assets/js/lootOpening.js
+++ b/html/assets/js/lootOpening.js
@@ -779,6 +779,19 @@ class LootReveal {
             card.classList.add('loot-reveal__item-card--ghost');
         }
 
+        const rarityClass = reward?.rarity
+            ? {
+                rare: 'loot-reveal__item-card--rare',
+                epic: 'loot-reveal__item-card--epic',
+                legendary: 'loot-reveal__item-card--legendary',
+                mythic: 'loot-reveal__item-card--mythic'
+            }[String(reward.rarity).toLowerCase()] ?? null
+            : null;
+
+        if (rarityClass) {
+            card.classList.add(rarityClass);
+        }
+
         const imageWrapper = document.createElement('div');
         imageWrapper.className = 'loot-reveal__item-card-image';
 
@@ -788,46 +801,14 @@ class LootReveal {
             img.alt = reward.name;
             imageWrapper.appendChild(img);
         } else {
-            const placeholder = document.createElement('div');
-            placeholder.textContent = reward.name.charAt(0).toUpperCase();
-            placeholder.style.fontSize = '2.8rem';
-            placeholder.style.fontWeight = '700';
-            placeholder.style.color = 'rgba(255, 255, 255, 0.7)';
-            imageWrapper.appendChild(placeholder);
+            imageWrapper.classList.add('loot-reveal__item-card-image--placeholder');
         }
-
-        if (reward.rarity && !ghost) {
-            const ring = document.createElement('div');
-            ring.className = 'loot-reveal__rarity-ring';
-            const rarityClass = {
-                common: '',
-                rare: 'loot-reveal__rarity-ring--rare',
-                epic: 'loot-reveal__rarity-ring--epic',
-                legendary: 'loot-reveal__rarity-ring--legendary'
-            }[String(reward.rarity).toLowerCase()];
-
-            if (rarityClass) {
-                ring.classList.add(rarityClass);
-            }
-
-            imageWrapper.appendChild(ring);
-        }
-
-        const name = document.createElement('div');
-        name.className = 'loot-reveal__item-name';
-        name.textContent = reward.name;
 
         const count = document.createElement('div');
         count.className = 'loot-reveal__item-count';
-        count.innerHTML = `
-            <span data-count>${reward.amount}</span>
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M4.5 6.75a2.25 2.25 0 0 1 2.25-2.25h10.5A2.25 2.25 0 0 1 19.5 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 17.25V6.75zm2.25-.75a.75.75 0 0 0-.75.75v10.5c0 .414.336.75.75.75h10.5a.75.75 0 0 0 .75-.75V6.75a.75.75 0 0 0-.75-.75H6.75zm5.25 2.25a.75.75 0 0 1 .75.75v2.25H15a.75.75 0 0 1 0 1.5h-2.25V15a.75.75 0 0 1-1.5 0v-2.25H9a.75.75 0 0 1 0-1.5h2.25V9a.75.75 0 0 1 .75-.75z"></path>
-            </svg>
-        `;
+        count.innerHTML = `<span data-count>${reward.amount}</span>`;
 
         card.appendChild(imageWrapper);
-        card.appendChild(name);
         card.appendChild(count);
 
         if (!ghost) {


### PR DESCRIPTION
## Summary
- replace loot reveal reward cards with image-focused tiles that carry rarity classes and a quantity badge only
- drop textual labels and SVG iconography from reward rendering to match the desired minimalist presentation
- restyle loot reveal CSS so the track and flight animations display just the item art with a numeric overlay

## Testing
- php -S 0.0.0.0:8000 -t html (for manual visual verification)


------
https://chatgpt.com/codex/tasks/task_b_68d0aea919608333a9323a22583c08da